### PR TITLE
fix(public-read): add skip sheet validation escape hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ holysheets google-sheets read find-many --help
 --spreadsheet-id <id>
 --sheet <name>
 --header-row <number>
+--skip-sheet-validation
 --format <json|csv|ndjson>
 --output <path>
 --pretty
@@ -84,10 +85,14 @@ Example config file:
   "defaults": {
     "spreadsheetId": "<ID>",
     "sheet": "<sheet-name>",
-    "headerRow": 2
+    "headerRow": 2,
+    "skipSheetValidation": false
   }
 }
 ```
+
+`--skip-sheet-validation` is an escape hatch that disables pre-checking whether the sheet name exists in public metadata.  
+It can reduce one network call, but it may allow silent fallback behavior from Google endpoints when the sheet name is invalid.
 
 ### Schema Input
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ You can run commands in both forms:
 
 ```bash
 # implicit source (google-sheets is the default)
-npx holysheets read find-many --sheet places --spreadsheet-id <ID>
+npx holysheets read find-many --sheet <sheet-name> --spreadsheet-id <ID>
 
 # explicit source
-npx holysheets google-sheets read find-many --sheet places --spreadsheet-id <ID>
+npx holysheets google-sheets read find-many --sheet <sheet-name> --spreadsheet-id <ID>
 ```
 
 ### Supported Commands
@@ -82,8 +82,8 @@ Example config file:
 ```json
 {
   "defaults": {
-    "spreadsheetId": "abc123",
-    "sheet": "places",
+    "spreadsheetId": "<ID>",
+    "sheet": "<sheet-name>",
     "headerRow": 2
   }
 }
@@ -116,7 +116,7 @@ Example:
 
 ```bash
 holysheets read find-many \
-  --sheet places \
+  --sheet <sheet-name> \
   --spreadsheet-id <ID> \
   --schema-field nome_estabelecimento --schema-type string \
   --schema-field rating --schema-type number \
@@ -141,7 +141,7 @@ Example:
 
 ```bash
 holysheets read find-many \
-  --sheet places \
+  --sheet <sheet-name> \
   --spreadsheet-id <ID> \
   --where-field rating --where-op gte --where-value 4 \
   --where-field nome_estabelecimento --where-op contains --where-value bar
@@ -153,11 +153,25 @@ holysheets read find-many \
 
 ```bash
 holysheets read find-many \
-  --sheet places \
+  --sheet <sheet-name> \
   --spreadsheet-id <ID> \
   --select nome_estabelecimento \
   --select rating
 ```
+
+### Omit
+
+`--omit` is repeatable:
+
+```bash
+holysheets read find-many \
+  --sheet <sheet-name> \
+  --spreadsheet-id <ID> \
+  --omit instagram \
+  --omit endereco
+```
+
+`--select` and `--omit` cannot be used together in the same command.
 
 ### Output and Formats
 
@@ -177,13 +191,14 @@ Output behavior:
 Examples:
 
 ```bash
-holysheets read find-many --sheet places --spreadsheet-id <ID> --format json --output ./out/places.json
-holysheets read find-many --sheet places --spreadsheet-id <ID> --format csv --output ./out/places.csv
+holysheets read find-many --sheet <sheet-name> --spreadsheet-id <ID> --format json --output ./out/data.json
+holysheets read find-many --sheet <sheet-name> --spreadsheet-id <ID> --format csv --output ./out/data.csv
 ```
 
 ### Describe Behavior
 
 `read describe` is metadata-focused and does not return data rows.
+It does not accept `--where-*`, `--select`, or `--omit`.
 
 It returns:
 
@@ -197,7 +212,7 @@ It returns:
 Example:
 
 ```bash
-holysheets read describe --sheet places --spreadsheet-id <ID> --header-row 2
+holysheets read describe --sheet <sheet-name> --spreadsheet-id <ID> --header-row 2
 ```
 
 Typical JSON output:
@@ -205,8 +220,8 @@ Typical JSON output:
 ```json
 {
   "source": "google-sheets",
-  "spreadsheetId": "abc123",
-  "sheet": "places",
+  "spreadsheetId": "<ID>",
+  "sheet": "<sheet-name>",
   "headerRow": 2,
   "columns": [
     { "index": 0, "name": "nome_estabelecimento" },

--- a/docs/en/cli/commands.md
+++ b/docs/en/cli/commands.md
@@ -165,11 +165,17 @@ All read commands accept the following flags:
 | `--sheet`          | Sheet name (**required**)               | —          |
 | `--config`         | Path to a JSON config file              | —          |
 | `--header-row`     | Header row number                       | `1`        |
+| `--skip-sheet-validation` | Skip pre-validation of sheet name (escape hatch) | `false` |
 | `--format`         | Output format (`json`, `csv`, `ndjson`) | `json`     |
 | `--output`         | Write output to file                    | stdout     |
 | `--pretty`         | Pretty-print JSON output                | `false`    |
 | `--select`         | Select specific fields (repeatable)     | all fields |
 | `--omit`           | Omit specific fields (repeatable)       | none       |
+
+::: warning
+`--skip-sheet-validation` disables the extra pre-check that fails fast when a sheet does not exist.  
+Use it only if you explicitly prefer fewer calls over stricter safety.
+:::
 
 See [Configuration](./configuration.md) for details on config files and flag precedence.
 

--- a/docs/en/cli/commands.md
+++ b/docs/en/cli/commands.md
@@ -16,7 +16,7 @@ Returns all records matching the given filters.
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --where-field rating --where-op gte --where-value 4 \
   --format json
 ```
@@ -32,15 +32,93 @@ Returns the first record matching the filters, or `null` if none is found.
 ```bash
 holysheets read find-first \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --where-field name --where-op equals --where-value "Cafe Central"
 ```
 
-Supported output formats: `json`, `ndjson`.
+---
+
+## `read find-unique`
+
+Returns a single record matching the filters, or `null` if none is found. Throws an error if **more than one** record matches.
+
+```bash
+holysheets read find-unique \
+  --spreadsheet-id <ID> \
+  --sheet <sheet-name> \
+  --where-field id --where-op equals --where-value "42"
+```
 
 ::: warning
-`csv` format is not supported for `find-first`.
+If multiple records match the filters, the command will exit with an error.
 :::
+
+---
+
+## `read find-last`
+
+Returns the last record matching the filters, or `null` if none is found.
+
+```bash
+holysheets read find-last \
+  --spreadsheet-id <ID> \
+  --sheet <sheet-name> \
+  --where-field city --where-op equals --where-value "São Paulo"
+```
+
+---
+
+## `read find-many-or-throw`
+
+Same as `find-many`, but exits with an error if **no records** are found.
+
+```bash
+holysheets read find-many-or-throw \
+  --spreadsheet-id <ID> \
+  --sheet <sheet-name> \
+  --where-field rating --where-op gte --where-value 4
+```
+
+Supports all output formats: `json`, `csv`, `ndjson`.
+
+---
+
+## `read find-first-or-throw`
+
+Same as `find-first`, but exits with an error if **no records** are found.
+
+```bash
+holysheets read find-first-or-throw \
+  --spreadsheet-id <ID> \
+  --sheet <sheet-name> \
+  --where-field name --where-op equals --where-value "Cafe Central"
+```
+
+---
+
+## `read find-unique-or-throw`
+
+Same as `find-unique`, but exits with an error if **no records** are found or if **multiple records** match.
+
+```bash
+holysheets read find-unique-or-throw \
+  --spreadsheet-id <ID> \
+  --sheet <sheet-name> \
+  --where-field id --where-op equals --where-value "42"
+```
+
+---
+
+## `read find-last-or-throw`
+
+Same as `find-last`, but exits with an error if **no records** are found.
+
+```bash
+holysheets read find-last-or-throw \
+  --spreadsheet-id <ID> \
+  --sheet <sheet-name> \
+  --where-field city --where-op equals --where-value "São Paulo"
+```
 
 ---
 
@@ -51,7 +129,7 @@ Returns metadata about the sheet, including detected columns and resolved schema
 ```bash
 holysheets read describe \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --header-row 2
 ```
 
@@ -61,7 +139,7 @@ Example output:
 {
   "source": "google-sheets",
   "spreadsheetId": "abc123",
-  "sheet": "places",
+  "sheet": "<sheet-name>",
   "headerRow": 2,
   "columns": [
     { "index": 0, "name": "nome_estabelecimento" },
@@ -72,7 +150,7 @@ Example output:
 ```
 
 ::: warning
-`describe` does not accept `--where-*` or `--select` flags.
+`describe` does not accept `--where-*`, `--select`, or `--omit` flags.
 :::
 
 ---
@@ -91,6 +169,7 @@ All read commands accept the following flags:
 | `--output`         | Write output to file                    | stdout     |
 | `--pretty`         | Pretty-print JSON output                | `false`    |
 | `--select`         | Select specific fields (repeatable)     | all fields |
+| `--omit`           | Omit specific fields (repeatable)       | none       |
 
 See [Configuration](./configuration.md) for details on config files and flag precedence.
 

--- a/docs/en/cli/configuration.md
+++ b/docs/en/cli/configuration.md
@@ -14,6 +14,7 @@ Create a JSON file (e.g., `holysheets.config.json`):
     "spreadsheetId": "1AbCDefGhIJkLMNOPQRS_TUVWXYZ",
     "sheet": "<sheet-name>",
     "headerRow": 2,
+    "skipSheetValidation": false,
     "format": "json",
     "pretty": true
   }
@@ -35,6 +36,7 @@ holysheets read find-many --config holysheets.config.json
 | `spreadsheetId` | `string`  | Google Spreadsheet ID |
 | `sheet`         | `string`  | Sheet name            |
 | `headerRow`     | `number`  | Header row number     |
+| `skipSheetValidation` | `boolean` | Skip pre-validation of sheet name |
 | `format`        | `string`  | Output format         |
 | `pretty`        | `boolean` | Pretty-print JSON     |
 

--- a/docs/en/cli/configuration.md
+++ b/docs/en/cli/configuration.md
@@ -12,7 +12,7 @@ Create a JSON file (e.g., `holysheets.config.json`):
 {
   "defaults": {
     "spreadsheetId": "1AbCDefGhIJkLMNOPQRS_TUVWXYZ",
-    "sheet": "places",
+    "sheet": "<sheet-name>",
     "headerRow": 2,
     "format": "json",
     "pretty": true
@@ -48,7 +48,7 @@ CLI flags always take priority over config file values:
 CLI flags  >  Config file defaults  >  Internal defaults
 ```
 
-For example, if your config file sets `"sheet": "places"` but you pass `--sheet cities`, the CLI will use `cities`.
+For example, if your config file sets `"sheet": "<sheet-name>"` but you pass `--sheet cities`, the CLI will use `cities`.
 
 ---
 

--- a/docs/en/cli/filters-and-select.md
+++ b/docs/en/cli/filters-and-select.md
@@ -1,6 +1,6 @@
 # CLI Filters and Select
 
-Use `--where-*` flags to filter records and `--select` to choose which fields to return.
+Use `--where-*` flags to filter records, `--select` to include fields, and `--omit` to exclude fields.
 
 ---
 
@@ -11,7 +11,7 @@ Filters are built using grouped flags. Each `--where-field` starts a new filter 
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --where-field rating --where-op gte --where-value 4 \
   --where-field name --where-op contains --where-value bar
 ```
@@ -71,7 +71,7 @@ You can apply multiple operators to the same field:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --where-field rating --where-op gte --where-value 3 \
   --where-field rating --where-op lte --where-value 5
 ```
@@ -87,7 +87,7 @@ Use `--select` to return only specific fields. It is repeatable:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --select name \
   --select rating
 ```
@@ -96,4 +96,26 @@ When `--select` is omitted, all fields are returned.
 
 ::: warning
 `--select` is not allowed with `read describe`.
+:::
+
+---
+
+## Omit
+
+Use `--omit` to exclude specific fields from the output. It is repeatable:
+
+```bash
+holysheets read find-many \
+  --spreadsheet-id <ID> \
+  --sheet <sheet-name> \
+  --omit instagram \
+  --omit endereco
+```
+
+::: warning
+`--omit` cannot be used together with `--select` in the same command.
+:::
+
+::: warning
+`--omit` is not allowed with `read describe`.
 :::

--- a/docs/en/cli/output.md
+++ b/docs/en/cli/output.md
@@ -14,14 +14,20 @@ Control how the CLI formats and delivers results using `--format`, `--output`, a
 
 ### Format Compatibility
 
-| Operation    | `json` | `ndjson` | `csv` |
-| ------------ | :----: | :------: | :---: |
-| `find-many`  |   ✅   |    ✅    |  ✅   |
-| `find-first` |   ✅   |    ✅    |  ❌   |
-| `describe`   |   ✅   |    ✅    |  ❌   |
+| Operation              | `json` | `ndjson` | `csv` |
+| ---------------------- | :----: | :------: | :---: |
+| `find-many`            |   ✅   |    ✅    |  ✅   |
+| `find-many-or-throw`   |   ✅   |    ✅    |  ✅   |
+| `find-first`           |   ✅   |    ✅    |  ✅   |
+| `find-unique`          |   ✅   |    ✅    |  ✅   |
+| `find-last`            |   ✅   |    ✅    |  ✅   |
+| `find-first-or-throw`  |   ✅   |    ✅    |  ✅   |
+| `find-unique-or-throw` |   ✅   |    ✅    |  ✅   |
+| `find-last-or-throw`   |   ✅   |    ✅    |  ✅   |
+| `describe`             |   ✅   |    ✅    |  ❌   |
 
-::: warning
-`csv` is only supported for `find-many` in this version. Using it with other commands will produce an error.
+::: tip
+`csv` works with all find operations. Single-record operations output a header row plus one data row. Only `describe` does not support CSV.
 :::
 
 ---
@@ -33,7 +39,7 @@ Use `--pretty` to format JSON output with indentation:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --format json \
   --pretty
 ```
@@ -64,7 +70,7 @@ By default, output is printed to **stdout**. Use `--output` to write to a file i
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --format csv \
   --output ./out/places.csv
 ```
@@ -80,7 +86,7 @@ Export all records as JSON to a file:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --format json \
   --pretty \
   --output ./out/places.json
@@ -91,7 +97,7 @@ Stream as NDJSON (useful for piping):
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --format ndjson | jq '.name'
 ```
 
@@ -100,7 +106,7 @@ Export filtered data as CSV:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --where-field rating --where-op gte --where-value 4 \
   --format csv \
   --output ./out/top-places.csv

--- a/docs/en/cli/overview.md
+++ b/docs/en/cli/overview.md
@@ -37,6 +37,9 @@ holysheets google-sheets read <operation> [flags]
 
 Both forms are functionally identical. The explicit form exists for future extensibility.
 
+By default, commands validate that `--sheet` exists before querying.  
+Use `--skip-sheet-validation` only as an escape hatch when you intentionally prefer fewer requests over stricter safety.
+
 ---
 
 ## Available Operations

--- a/docs/en/cli/overview.md
+++ b/docs/en/cli/overview.md
@@ -11,12 +11,12 @@ The CLI ships with the `holysheets` package. Install it globally or use `npx`:
 ::: code-group
 
 ```bash [npx]
-npx holysheets read find-many --sheet places --spreadsheet-id <ID>
+npx holysheets read find-many --sheet <sheet-name> --spreadsheet-id <ID>
 ```
 
 ```bash [global install]
 npm install -g holysheets
-holysheets read find-many --sheet places --spreadsheet-id <ID>
+holysheets read find-many --sheet <sheet-name> --spreadsheet-id <ID>
 ```
 
 :::
@@ -41,11 +41,17 @@ Both forms are functionally identical. The explicit form exists for future exten
 
 ## Available Operations
 
-| Operation    | Description                                  |
-| ------------ | -------------------------------------------- |
-| `find-many`  | Returns all records matching the filters.    |
-| `find-first` | Returns the first matching record.           |
-| `describe`   | Returns sheet metadata (columns and schema). |
+| Operation              | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
+| `find-many`            | Returns all records matching the filters.              |
+| `find-first`           | Returns the first matching record.                     |
+| `find-unique`          | Returns a single matching record (errors if multiple). |
+| `find-last`            | Returns the last matching record.                      |
+| `find-many-or-throw`   | Like `find-many`, but errors if no records found.      |
+| `find-first-or-throw`  | Like `find-first`, but errors if no records found.     |
+| `find-unique-or-throw` | Like `find-unique`, but errors if none or multiple.    |
+| `find-last-or-throw`   | Like `find-last`, but errors if no records found.      |
+| `describe`             | Returns sheet metadata (columns and schema).           |
 
 ---
 
@@ -54,7 +60,7 @@ Both forms are functionally identical. The explicit form exists for future exten
 ```bash
 holysheets read find-many \
   --spreadsheet-id 1AbCDefGhIJkLMNOPQRS_TUVWXYZ \
-  --sheet places \
+  --sheet <sheet-name> \
   --where-field rating --where-op gte --where-value 4 \
   --select name \
   --select rating \

--- a/docs/en/cli/schema.md
+++ b/docs/en/cli/schema.md
@@ -17,7 +17,7 @@ Point to a JSON file containing an array of schema definitions:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --schema-file ./schema.json
 ```
 
@@ -38,7 +38,7 @@ Pass the schema directly as a JSON string:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --schema-json '[{"key":"name","type":"string"},{"key":"rating","type":"number"}]'
 ```
 
@@ -49,7 +49,7 @@ Define the schema field by field using grouped flags:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --schema-field nome_estabelecimento --schema-type string \
   --schema-field rating --schema-type number \
   --schema-field visitado_em --schema-type date --schema-nullable
@@ -88,7 +88,7 @@ Use `--schema-alias` to rename columns in the output:
 ```bash
 holysheets read find-many \
   --spreadsheet-id <ID> \
-  --sheet places \
+  --sheet <sheet-name> \
   --schema-field nome_estabelecimento --schema-type string --schema-alias name \
   --schema-field rating --schema-type number
 ```

--- a/docs/en/guides/public-mode.md
+++ b/docs/en/guides/public-mode.md
@@ -205,5 +205,6 @@ Sets the target sheet.
 | ----------- | -------- | ------- | ----------------------------- |
 | `sheetName` | `string` | —       | The name of the sheet (tab).  |
 | `headerRow` | `number` | `1`     | The row number of the header. |
+| `skipSheetValidation` | `boolean` | `false` | Skip pre-validation of sheet name before querying. |
 
 **Returns**: A typed reader with find methods.

--- a/src/cli/commands/runReadCommand.spec.ts
+++ b/src/cli/commands/runReadCommand.spec.ts
@@ -32,6 +32,7 @@ function createCommand(
     spreadsheetId: 'spreadsheet-id',
     sheet: 'pokemon',
     headerRow: 1,
+    skipSheetValidation: false,
     format: 'json',
     pretty: false,
     select: [],
@@ -86,7 +87,19 @@ describe('runReadCommand', () => {
     expect(publicMock).toHaveBeenCalledWith({
       spreadsheetId: 'spreadsheet-id'
     })
-    expect(baseMock).toHaveBeenCalledWith('pokemon', { headerRow: 1 })
+    expect(baseMock).toHaveBeenCalledWith('pokemon', {
+      headerRow: 1,
+      skipSheetValidation: false
+    })
+  })
+
+  it('passes skipSheetValidation=true to base when provided by normalized command', async () => {
+    await runReadCommand(createCommand({ skipSheetValidation: true }))
+
+    expect(baseMock).toHaveBeenCalledWith('pokemon', {
+      headerRow: 1,
+      skipSheetValidation: true
+    })
   })
 
   it('calls defineSchema when schema is provided', async () => {

--- a/src/cli/commands/runReadCommand.spec.ts
+++ b/src/cli/commands/runReadCommand.spec.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HolySheets from '@/index'
+import { runReadCommand } from '@/cli/commands/runReadCommand'
+import { CliRecord, NormalizedReadCommand } from '@/cli/types'
+
+vi.mock('@/index', () => ({
+  default: {
+    public: vi.fn()
+  }
+}))
+
+type MockTable = {
+  defineSchema: ReturnType<typeof vi.fn>
+  findMany: ReturnType<typeof vi.fn>
+  findFirst: ReturnType<typeof vi.fn>
+  findUnique: ReturnType<typeof vi.fn>
+  findLast: ReturnType<typeof vi.fn>
+  findManyOrThrow: ReturnType<typeof vi.fn>
+  findFirstOrThrow: ReturnType<typeof vi.fn>
+  findUniqueOrThrow: ReturnType<typeof vi.fn>
+  findLastOrThrow: ReturnType<typeof vi.fn>
+  getHeaders: ReturnType<typeof vi.fn>
+}
+
+function createCommand(
+  overrides: Partial<NormalizedReadCommand> = {}
+): NormalizedReadCommand {
+  return {
+    source: 'google-sheets',
+    operation: 'find-many',
+    spreadsheetId: 'spreadsheet-id',
+    sheet: 'pokemon',
+    headerRow: 1,
+    format: 'json',
+    pretty: false,
+    select: [],
+    omit: [],
+    where: {},
+    ...overrides
+  }
+}
+
+describe('runReadCommand', () => {
+  let table: MockTable
+  let publicMock: ReturnType<typeof vi.fn>
+  let baseMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    table = {
+      defineSchema: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([{ id: '1' } satisfies CliRecord]),
+      findFirst: vi.fn().mockResolvedValue({ id: '1' } satisfies CliRecord),
+      findUnique: vi.fn().mockResolvedValue({ id: '2' } satisfies CliRecord),
+      findLast: vi.fn().mockResolvedValue({ id: '3' } satisfies CliRecord),
+      findManyOrThrow: vi
+        .fn()
+        .mockResolvedValue([{ id: '4' } satisfies CliRecord]),
+      findFirstOrThrow: vi
+        .fn()
+        .mockResolvedValue({ id: '5' } satisfies CliRecord),
+      findUniqueOrThrow: vi
+        .fn()
+        .mockResolvedValue({ id: '6' } satisfies CliRecord),
+      findLastOrThrow: vi
+        .fn()
+        .mockResolvedValue({ id: '7' } satisfies CliRecord),
+      getHeaders: vi.fn().mockResolvedValue([
+        { header: 'name', column: 0 },
+        { header: 'type1', column: 1 }
+      ])
+    }
+
+    baseMock = vi.fn().mockReturnValue(table)
+    publicMock = vi.fn().mockReturnValue({
+      base: baseMock
+    })
+    ;(
+      HolySheets.public as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(publicMock)
+  })
+
+  it('calls HolySheets.public().base() with sheet and headerRow', async () => {
+    await runReadCommand(createCommand())
+
+    expect(publicMock).toHaveBeenCalledWith({
+      spreadsheetId: 'spreadsheet-id'
+    })
+    expect(baseMock).toHaveBeenCalledWith('pokemon', { headerRow: 1 })
+  })
+
+  it('calls defineSchema when schema is provided', async () => {
+    const schema = [{ key: 'name', type: 'string' as const }]
+    await runReadCommand(createCommand({ schema }))
+
+    expect(table.defineSchema).toHaveBeenCalledWith(schema)
+  })
+
+  it('runs find-many with where only when select/omit are empty', async () => {
+    const result = await runReadCommand(
+      createCommand({ operation: 'find-many' })
+    )
+
+    expect(table.findMany).toHaveBeenCalledWith({ where: {} })
+    expect(result).toEqual([{ id: '1' }])
+  })
+
+  it('passes select and omit when provided', async () => {
+    await runReadCommand(
+      createCommand({
+        operation: 'find-many',
+        where: { type1: { equals: 'Fire' } },
+        select: ['name', 'type1'],
+        omit: ['internal_notes']
+      })
+    )
+
+    expect(table.findMany).toHaveBeenCalledWith({
+      where: { type1: { equals: 'Fire' } },
+      select: ['name', 'type1'],
+      omit: ['internal_notes']
+    })
+  })
+
+  it('returns null for find-first when no record is found', async () => {
+    table.findFirst.mockResolvedValueOnce(undefined)
+
+    const result = await runReadCommand(
+      createCommand({ operation: 'find-first' })
+    )
+
+    expect(table.findFirst).toHaveBeenCalledWith({ where: {} })
+    expect(result).toBeNull()
+  })
+
+  it('returns null for find-unique and find-last when no record is found', async () => {
+    table.findUnique.mockResolvedValueOnce(undefined)
+    table.findLast.mockResolvedValueOnce(undefined)
+
+    const uniqueResult = await runReadCommand(
+      createCommand({ operation: 'find-unique' })
+    )
+    const lastResult = await runReadCommand(
+      createCommand({ operation: 'find-last' })
+    )
+
+    expect(uniqueResult).toBeNull()
+    expect(lastResult).toBeNull()
+  })
+
+  it('runs all throw-variants', async () => {
+    expect(
+      await runReadCommand(createCommand({ operation: 'find-many-or-throw' }))
+    ).toEqual([{ id: '4' }])
+    expect(
+      await runReadCommand(createCommand({ operation: 'find-first-or-throw' }))
+    ).toEqual({ id: '5' })
+    expect(
+      await runReadCommand(createCommand({ operation: 'find-unique-or-throw' }))
+    ).toEqual({ id: '6' })
+    expect(
+      await runReadCommand(createCommand({ operation: 'find-last-or-throw' }))
+    ).toEqual({ id: '7' })
+
+    expect(table.findManyOrThrow).toHaveBeenCalledWith({ where: {} })
+    expect(table.findFirstOrThrow).toHaveBeenCalledWith({ where: {} })
+    expect(table.findUniqueOrThrow).toHaveBeenCalledWith({ where: {} })
+    expect(table.findLastOrThrow).toHaveBeenCalledWith({ where: {} })
+  })
+
+  it('returns describe metadata with resolved columns and schema fallback', async () => {
+    const resultWithoutSchema = await runReadCommand(
+      createCommand({ operation: 'describe', schema: undefined })
+    )
+
+    expect(resultWithoutSchema).toEqual({
+      source: 'google-sheets',
+      spreadsheetId: 'spreadsheet-id',
+      sheet: 'pokemon',
+      headerRow: 1,
+      columns: [
+        { index: 0, name: 'name' },
+        { index: 1, name: 'type1' }
+      ],
+      schema: []
+    })
+
+    const resultWithSchema = await runReadCommand(
+      createCommand({
+        operation: 'describe',
+        schema: [{ key: 'name', type: 'string' as const }]
+      })
+    )
+
+    expect(resultWithSchema).toEqual({
+      source: 'google-sheets',
+      spreadsheetId: 'spreadsheet-id',
+      sheet: 'pokemon',
+      headerRow: 1,
+      columns: [
+        { index: 0, name: 'name' },
+        { index: 1, name: 'type1' }
+      ],
+      schema: [{ key: 'name', type: 'string' }]
+    })
+  })
+})

--- a/src/cli/commands/runReadCommand.ts
+++ b/src/cli/commands/runReadCommand.ts
@@ -12,12 +12,44 @@ type PublicReadTable = {
   defineSchema: (schema: RecordSchema<CliRecord>) => unknown
   findMany: (options: {
     where: WhereClause<CliRecord>
-    select: string[]
+    select?: string[]
+    omit?: string[]
   }) => Promise<CliRecord[]>
   findFirst: (options: {
     where: WhereClause<CliRecord>
-    select: string[]
+    select?: string[]
+    omit?: string[]
   }) => Promise<CliRecord | undefined>
+  findUnique: (options: {
+    where: WhereClause<CliRecord>
+    select?: string[]
+    omit?: string[]
+  }) => Promise<CliRecord | undefined>
+  findLast: (options: {
+    where: WhereClause<CliRecord>
+    select?: string[]
+    omit?: string[]
+  }) => Promise<CliRecord | undefined>
+  findManyOrThrow: (options: {
+    where: WhereClause<CliRecord>
+    select?: string[]
+    omit?: string[]
+  }) => Promise<CliRecord[]>
+  findFirstOrThrow: (options: {
+    where: WhereClause<CliRecord>
+    select?: string[]
+    omit?: string[]
+  }) => Promise<CliRecord>
+  findUniqueOrThrow: (options: {
+    where: WhereClause<CliRecord>
+    select?: string[]
+    omit?: string[]
+  }) => Promise<CliRecord>
+  findLastOrThrow: (options: {
+    where: WhereClause<CliRecord>
+    select?: string[]
+    omit?: string[]
+  }) => Promise<CliRecord>
   getHeaders: () => Promise<HeaderColumn[]>
 }
 
@@ -36,32 +68,66 @@ export async function runReadCommand(
     table.defineSchema(command.schema)
   }
 
-  if (command.operation === 'find-many') {
-    const records = await table.findMany({
-      where: command.where,
-      select: command.select
-    })
-    return records
+  const findOptions: {
+    where: WhereClause<CliRecord>
+    select?: string[]
+    omit?: string[]
+  } = {
+    where: command.where
   }
 
-  if (command.operation === 'find-first') {
-    const record = await table.findFirst({
-      where: command.where,
-      select: command.select
-    })
-    return record ?? null
+  if (command.select.length > 0) {
+    findOptions.select = command.select
   }
 
-  const headers = await table.getHeaders()
-  return {
-    source: command.source,
-    spreadsheetId: command.spreadsheetId,
-    sheet: command.sheet,
-    headerRow: command.headerRow,
-    columns: headers.map(header => ({
-      index: header.column,
-      name: header.header
-    })),
-    schema: command.schema ?? []
+  if (command.omit.length > 0) {
+    findOptions.omit = command.omit
+  }
+
+  switch (command.operation) {
+    case 'find-many':
+      return await table.findMany(findOptions)
+
+    case 'find-first': {
+      const record = await table.findFirst(findOptions)
+      return record ?? null
+    }
+
+    case 'find-unique': {
+      const record = await table.findUnique(findOptions)
+      return record ?? null
+    }
+
+    case 'find-last': {
+      const record = await table.findLast(findOptions)
+      return record ?? null
+    }
+
+    case 'find-many-or-throw':
+      return await table.findManyOrThrow(findOptions)
+
+    case 'find-first-or-throw':
+      return await table.findFirstOrThrow(findOptions)
+
+    case 'find-unique-or-throw':
+      return await table.findUniqueOrThrow(findOptions)
+
+    case 'find-last-or-throw':
+      return await table.findLastOrThrow(findOptions)
+
+    case 'describe': {
+      const headers = await table.getHeaders()
+      return {
+        source: command.source,
+        spreadsheetId: command.spreadsheetId,
+        sheet: command.sheet,
+        headerRow: command.headerRow,
+        columns: headers.map(header => ({
+          index: header.column,
+          name: header.header
+        })),
+        schema: command.schema ?? []
+      }
+    }
   }
 }

--- a/src/cli/commands/runReadCommand.ts
+++ b/src/cli/commands/runReadCommand.ts
@@ -61,7 +61,8 @@ export async function runReadCommand(
   })
 
   const table = reader.base<CliRecord>(command.sheet, {
-    headerRow: command.headerRow
+    headerRow: command.headerRow,
+    skipSheetValidation: command.skipSheetValidation
   }) as unknown as PublicReadTable
 
   if (command.schema) {

--- a/src/cli/config/readCliConfig.spec.ts
+++ b/src/cli/config/readCliConfig.spec.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { CliError } from '@/cli/errors/CliError'
+import { readCliConfig } from '@/cli/config/readCliConfig'
+
+describe('readCliConfig', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns empty object when path is not provided', () => {
+    expect(readCliConfig()).toEqual({})
+  })
+
+  it('throws when config file does not exist', () => {
+    expect(() => readCliConfig('./missing-config.json')).toThrowError(CliError)
+  })
+
+  it('reads and parses a valid config file', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-cli-config-'))
+    const configPath = path.join(tempDir, 'config.json')
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        defaults: {
+          spreadsheetId: 'abc',
+          sheet: 'pokemon',
+          headerRow: 2
+        }
+      })
+    )
+
+    const config = readCliConfig(configPath)
+    expect(config).toEqual({
+      defaults: {
+        spreadsheetId: 'abc',
+        sheet: 'pokemon',
+        headerRow: 2
+      }
+    })
+  })
+
+  it('throws when file cannot be read', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-cli-config-'))
+    const configPath = path.join(tempDir, 'config.json')
+    fs.writeFileSync(configPath, '{"defaults":{"sheet":"pokemon"}}')
+
+    vi.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
+      throw new Error('permission denied')
+    })
+
+    expect(() => readCliConfig(configPath)).toThrowError(
+      /Could not read config file/
+    )
+  })
+
+  it('throws when config file has invalid json', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-cli-config-'))
+    const configPath = path.join(tempDir, 'config.json')
+    fs.writeFileSync(configPath, '{"defaults":')
+
+    expect(() => readCliConfig(configPath)).toThrowError(
+      /Invalid JSON in config file/
+    )
+  })
+
+  it('throws when parsed config is not an object', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-cli-config-'))
+    const configPath = path.join(tempDir, 'config.json')
+    fs.writeFileSync(configPath, '42')
+
+    expect(() => readCliConfig(configPath)).toThrowError(
+      /Invalid JSON in config file/
+    )
+  })
+})

--- a/src/cli/index.spec.ts
+++ b/src/cli/index.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const runCliMock = vi.fn()
+
+vi.mock('@/cli/runCli', () => ({
+  runCli: runCliMock
+}))
+
+describe('cli index entrypoint', () => {
+  const originalArgv = process.argv
+
+  afterEach(() => {
+    process.argv = originalArgv
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('forwards process argv slice(2) to runCli', async () => {
+    process.argv = [
+      'node',
+      'holysheets',
+      'read',
+      'find-many',
+      '--sheet',
+      'pokemon'
+    ]
+
+    await import('@/cli/index')
+
+    expect(runCliMock).toHaveBeenCalledWith([
+      'read',
+      'find-many',
+      '--sheet',
+      'pokemon'
+    ])
+  })
+})

--- a/src/cli/normalize/normalizeReadCommand.spec.ts
+++ b/src/cli/normalize/normalizeReadCommand.spec.ts
@@ -10,6 +10,7 @@ import { ParsedReadFlags } from '@/cli/types'
 
 function createBaseFlags(): ParsedReadFlags {
   return {
+    skipSheetValidation: false,
     pretty: false,
     select: [],
     omit: [],
@@ -46,6 +47,7 @@ describe('normalizeReadCommand', () => {
     expect(normalized.spreadsheetId).toBe('flag-id')
     expect(normalized.sheet).toBe('places')
     expect(normalized.headerRow).toBe(2)
+    expect(normalized.skipSheetValidation).toBe(false)
     expect(normalized.where).toEqual({
       rating: { gte: 4, lte: 5 }
     })
@@ -193,6 +195,43 @@ describe('normalizeReadCommand', () => {
     })
 
     expect(normalized.pretty).toBe(true)
+  })
+
+  it('uses skipSheetValidation=true from config when cli flag is absent', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+
+    const normalized = normalizeReadCommand({
+      operation: 'find-first',
+      flags,
+      config: {
+        defaults: {
+          skipSheetValidation: true
+        }
+      }
+    })
+
+    expect(normalized.skipSheetValidation).toBe(true)
+  })
+
+  it('uses skipSheetValidation=true from cli flag even when config default is false', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.skipSheetValidation = true
+
+    const normalized = normalizeReadCommand({
+      operation: 'find-first',
+      flags,
+      config: {
+        defaults: {
+          skipSheetValidation: false
+        }
+      }
+    })
+
+    expect(normalized.skipSheetValidation).toBe(true)
   })
 
   it('fails when spreadsheet id is missing in flags and config', () => {

--- a/src/cli/normalize/normalizeReadCommand.spec.ts
+++ b/src/cli/normalize/normalizeReadCommand.spec.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { CliError } from '@/cli/errors/CliError'
 import { normalizeReadCommand } from '@/cli/normalize/normalizeReadCommand'
@@ -12,12 +12,17 @@ function createBaseFlags(): ParsedReadFlags {
   return {
     pretty: false,
     select: [],
+    omit: [],
     schemaBlocks: [],
     whereBlocks: []
   }
 }
 
 describe('normalizeReadCommand', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('applies precedence: CLI flags > config > defaults', () => {
     const flags = createBaseFlags()
     flags.spreadsheetId = 'flag-id'
@@ -102,5 +107,588 @@ describe('normalizeReadCommand', () => {
         config: {}
       })
     ).toThrowError(CliError)
+  })
+
+  it('fails when select and omit are used together', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.select = ['name']
+    flags.omit = ['rating']
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(CliError)
+  })
+
+  it('fails when omit is used with describe', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.omit = ['rating']
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'describe',
+        flags,
+        config: {}
+      })
+    ).toThrowError(CliError)
+  })
+
+  it('uses internal defaults when flags/config are missing optional values', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+
+    const normalized = normalizeReadCommand({
+      operation: 'find-first',
+      flags,
+      config: {}
+    })
+
+    expect(normalized.headerRow).toBe(1)
+    expect(normalized.format).toBe('json')
+    expect(normalized.pretty).toBe(false)
+    expect(normalized.schema).toBeUndefined()
+    expect(normalized.where).toEqual({})
+  })
+
+  it('uses pretty=true from config when cli flag is absent', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+
+    const normalized = normalizeReadCommand({
+      operation: 'find-first',
+      flags,
+      config: {
+        defaults: {
+          pretty: true
+        }
+      }
+    })
+
+    expect(normalized.pretty).toBe(true)
+  })
+
+  it('uses pretty=true from cli flag even when config default is false', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.pretty = true
+
+    const normalized = normalizeReadCommand({
+      operation: 'find-first',
+      flags,
+      config: {
+        defaults: {
+          pretty: false
+        }
+      }
+    })
+
+    expect(normalized.pretty).toBe(true)
+  })
+
+  it('fails when spreadsheet id is missing in flags and config', () => {
+    const flags = createBaseFlags()
+    flags.sheet = 'places'
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Missing required option "--spreadsheet-id" (or provide it in config.defaults.spreadsheetId).'
+      )
+    )
+  })
+
+  it('fails when sheet is missing in flags and config', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Missing required option "--sheet" (or provide it in config.defaults.sheet).'
+      )
+    )
+  })
+
+  it('fails on invalid header row values', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.headerRow = '0'
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Invalid value for "--header-row": "0". Use an integer >= 1.'
+      )
+    )
+  })
+
+  it('fails on invalid format', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.format = 'table'
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Invalid value for "--format": "table". Allowed values: json, csv, ndjson.'
+      )
+    )
+  })
+
+  it('fails when more than one schema source is provided', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = '[]'
+    flags.schemaBlocks = [{ field: 'name', type: 'string' }]
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Use only one schema source at a time: --schema-file OR --schema-json OR --schema-field/... flags.'
+      )
+    )
+  })
+
+  it('parses schema from json with alias and nullable', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = JSON.stringify([
+      { key: 'name', type: 'string', as: 'label' },
+      { key: 'active', type: 'boolean', nullable: false }
+    ])
+
+    const normalized = normalizeReadCommand({
+      operation: 'find-many',
+      flags,
+      config: {}
+    })
+
+    expect(normalized.schema).toEqual([
+      { key: 'name', type: 'string', as: 'label' },
+      { key: 'active', type: 'boolean', nullable: false }
+    ])
+  })
+
+  it('fails on invalid json in --schema-json', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = '[invalid'
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(/Invalid JSON in "--schema-json":/)
+  })
+
+  it('fails when --schema-json is not an array', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = JSON.stringify({ key: 'name', type: 'string' })
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      /Invalid JSON in "--schema-json": Schema from --schema-json must be a JSON array\./
+    )
+  })
+
+  it('fails when schema item is not an object', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = JSON.stringify(['name'])
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      /Invalid JSON in "--schema-json": Invalid schema item at index 0 from --schema-json\./
+    )
+  })
+
+  it('fails when schema key is missing', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = JSON.stringify([{ type: 'string' }])
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      /Invalid JSON in "--schema-json": Schema item at index 0 from --schema-json must contain a non-empty "key"\./
+    )
+  })
+
+  it('fails when schema type is missing', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = JSON.stringify([{ key: 'name' }])
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      /Invalid JSON in "--schema-json": Schema item "name" from --schema-json must contain a valid "type"\./
+    )
+  })
+
+  it('fails when schema alias is invalid', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = JSON.stringify([{ key: 'name', type: 'string', as: 1 }])
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      /Invalid JSON in "--schema-json": Schema item "name" from --schema-json has an invalid "as" value\./
+    )
+  })
+
+  it('fails when schema nullable is invalid', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = JSON.stringify([
+      { key: 'name', type: 'string', nullable: 'true' }
+    ])
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      /Invalid JSON in "--schema-json": Schema item "name" from --schema-json has an invalid "nullable" value\./
+    )
+  })
+
+  it('fails when schema type is unsupported', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaJson = JSON.stringify([{ key: 'name', type: 'datetime' }])
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      /Invalid JSON in "--schema-json": Invalid schema type "datetime"\. Allowed values: string, number, boolean, date\./
+    )
+  })
+
+  it('fails when schema file does not exist', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaFile = './does-not-exist.schema.json'
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(/Schema file not found:/)
+  })
+
+  it('fails when schema file cannot be read', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'holysheets-cli-'))
+    const schemaPath = path.join(tmpDir, 'schema.json')
+    fs.writeFileSync(schemaPath, '[]')
+    vi.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
+      throw new Error('EACCES')
+    })
+
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaFile = schemaPath
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(/Could not read schema file/)
+  })
+
+  it('fails when schema file has invalid json', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'holysheets-cli-'))
+    const schemaPath = path.join(tmpDir, 'schema.json')
+    fs.writeFileSync(schemaPath, '[invalid]')
+
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaFile = schemaPath
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(/Invalid JSON in schema file/)
+  })
+
+  it('fails when schema block is incomplete', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaBlocks = [{ field: 'name' }]
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Schema field "name" is incomplete. Missing "--schema-type".'
+      )
+    )
+  })
+
+  it('parses schema from flag blocks with alias and nullable', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.schemaBlocks = [
+      { field: 'name', type: 'string', alias: 'label' },
+      { field: 'rating', type: 'number', nullable: true }
+    ]
+
+    const normalized = normalizeReadCommand({
+      operation: 'find-many',
+      flags,
+      config: {}
+    })
+
+    expect(normalized.schema).toEqual([
+      { key: 'name', type: 'string', as: 'label' },
+      { key: 'rating', type: 'number', nullable: true }
+    ])
+  })
+
+  it('fails when where block has no operator', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.whereBlocks = [{ field: 'name', values: ['foo'] }]
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError('Filter for field "name" is incomplete. Missing "--where-op".')
+    )
+  })
+
+  it('parses in/notIn where operators and merges repeated array filters', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.whereBlocks = [
+      { field: 'tags', op: 'in', values: ['fire'] },
+      { field: 'tags', op: 'in', values: ['flying'] },
+      { field: 'name', op: 'notIn', values: ['weedle'] }
+    ]
+
+    const normalized = normalizeReadCommand({
+      operation: 'find-many',
+      flags,
+      config: {}
+    })
+
+    expect(normalized.where).toEqual({
+      tags: { in: ['fire', 'flying'] },
+      name: { notIn: ['weedle'] }
+    })
+  })
+
+  it('fails when array where operators receive no values', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.whereBlocks = [{ field: 'name', op: 'in', values: [] }]
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Filter operator "in" requires at least one "--where-value".'
+      )
+    )
+  })
+
+  it('fails when scalar where operators receive multiple values', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.whereBlocks = [{ field: 'name', op: 'equals', values: ['a', 'b'] }]
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Filter operator "equals" requires exactly one "--where-value".'
+      )
+    )
+  })
+
+  it('fails when numeric where operators receive non-numeric value', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.whereBlocks = [{ field: 'rating', op: 'gte', values: ['high'] }]
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Filter operator "gte" requires a numeric "--where-value". Received "high".'
+      )
+    )
+  })
+
+  it('fails when non-array operator is duplicated for same field', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.whereBlocks = [
+      { field: 'name', op: 'contains', values: ['bar'] },
+      { field: 'name', op: 'contains', values: ['cafe'] }
+    ]
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'find-many',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError(
+        'Duplicate filter for field "name" with operator "contains".'
+      )
+    )
+  })
+
+  it('fails when where filters are used with describe', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.whereBlocks = [{ field: 'name', op: 'contains', values: ['bar'] }]
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'describe',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError('Command "read describe" does not accept where filters.')
+    )
+  })
+
+  it('fails when select is used with describe', () => {
+    const flags = createBaseFlags()
+    flags.spreadsheetId = 'id'
+    flags.sheet = 'places'
+    flags.select = ['name']
+
+    expect(() =>
+      normalizeReadCommand({
+        operation: 'describe',
+        flags,
+        config: {}
+      })
+    ).toThrowError(
+      new CliError('Command "read describe" does not accept "--select".')
+    )
   })
 })

--- a/src/cli/normalize/normalizeReadCommand.ts
+++ b/src/cli/normalize/normalizeReadCommand.ts
@@ -334,6 +334,9 @@ export function normalizeReadCommand({
   const spreadsheetId = flags.spreadsheetId ?? defaults.spreadsheetId
   const sheet = flags.sheet ?? defaults.sheet
   const headerRow = parseHeaderRow(flags.headerRow ?? defaults.headerRow)
+  const skipSheetValidation = flags.skipSheetValidation
+    ? true
+    : Boolean(defaults.skipSheetValidation ?? false)
   const format = parseFormat(flags.format ?? defaults.format)
   const pretty = flags.pretty ? true : Boolean(defaults.pretty ?? false)
 
@@ -380,6 +383,7 @@ export function normalizeReadCommand({
     spreadsheetId,
     sheet,
     headerRow,
+    skipSheetValidation,
     format,
     output: flags.output,
     pretty,

--- a/src/cli/normalize/normalizeReadCommand.ts
+++ b/src/cli/normalize/normalizeReadCommand.ts
@@ -277,10 +277,7 @@ function mergeWhereCondition(
     return
   }
 
-  const conditionObject: WhereCondition =
-    typeof existingCondition === 'string'
-      ? { equals: existingCondition }
-      : existingCondition
+  const conditionObject = existingCondition as WhereCondition
 
   const alreadyDefined = conditionObject[op as keyof WhereCondition]
   if (alreadyDefined !== undefined) {
@@ -303,7 +300,7 @@ function mergeWhereCondition(
 }
 
 function resolveWhere(flags: ParsedReadFlags): WhereClause<CliRecord> {
-  const where: WhereClause<CliRecord> = {}
+  const where: WhereClause<CliRecord> = Object.create(null)
 
   for (const block of flags.whereBlocks) {
     if (!block.op) {
@@ -363,10 +360,18 @@ export function normalizeReadCommand({
     throw new CliError('Command "read describe" does not accept "--select".')
   }
 
-  if (format === 'csv' && operation !== 'find-many') {
+  if (operation === 'describe' && flags.omit.length > 0) {
+    throw new CliError('Command "read describe" does not accept "--omit".')
+  }
+
+  if (flags.select.length > 0 && flags.omit.length > 0) {
     throw new CliError(
-      `Format "csv" is only supported for "read find-many" in this version.`
+      'Options "--select" and "--omit" cannot be used together in the same command.'
     )
+  }
+
+  if (format === 'csv' && operation === 'describe') {
+    throw new CliError('Format "csv" is not supported for "read describe".')
   }
 
   return {
@@ -379,6 +384,7 @@ export function normalizeReadCommand({
     output: flags.output,
     pretty,
     select: flags.select,
+    omit: flags.omit,
     where,
     schema
   }

--- a/src/cli/output/serializeOutput.spec.ts
+++ b/src/cli/output/serializeOutput.spec.ts
@@ -13,6 +13,7 @@ function baseCommand(
     spreadsheetId: 'id',
     sheet: 'places',
     headerRow: 1,
+    skipSheetValidation: false,
     format: 'json',
     pretty: false,
     select: [],

--- a/src/cli/output/serializeOutput.spec.ts
+++ b/src/cli/output/serializeOutput.spec.ts
@@ -16,6 +16,7 @@ function baseCommand(
     format: 'json',
     pretty: false,
     select: [],
+    omit: [],
     where: {},
     ...overrides
   }
@@ -43,5 +44,83 @@ describe('serializeOutput', () => {
     const command = baseCommand({ operation: 'describe', format: 'csv' })
 
     expect(() => serializeOutput(command, { a: 1 })).toThrowError(CliError)
+  })
+
+  it('serializes json with pretty output when requested', () => {
+    const command = baseCommand({ format: 'json', pretty: true })
+    const output = serializeOutput(command, { name: 'Pikachu', stats: { hp: 35 } })
+
+    expect(output).toBe('{\n  "name": "Pikachu",\n  "stats": {\n    "hp": 35\n  }\n}')
+  })
+
+  it('serializes ndjson for find-many arrays', () => {
+    const command = baseCommand({ format: 'ndjson', operation: 'find-many' })
+    const output = serializeOutput(command, [{ id: 1 }, { id: 2 }])
+
+    expect(output).toBe('{"id":1}\n{"id":2}')
+  })
+
+  it('serializes ndjson for find-many non-array values as empty output', () => {
+    const command = baseCommand({ format: 'ndjson', operation: 'find-many' })
+    const output = serializeOutput(command, { id: 1 })
+
+    expect(output).toBe('')
+  })
+
+  it('serializes ndjson as single json for non-list operations', () => {
+    const command = baseCommand({ format: 'ndjson', operation: 'find-first' })
+    const output = serializeOutput(command, { id: 25 })
+
+    expect(output).toBe('{"id":25}')
+  })
+
+  it('serializes csv from single-object results', () => {
+    const command = baseCommand({ format: 'csv', operation: 'find-first' })
+    const output = serializeOutput(command, { name: 'Eevee', rarity: 'rare' })
+
+    expect(output).toBe('name,rarity\nEevee,rare')
+  })
+
+  it('serializes csv as empty content for nullish non-array data', () => {
+    const command = baseCommand({ format: 'csv', operation: 'find-first' })
+
+    expect(serializeOutput(command, null)).toBe('')
+    expect(serializeOutput(command, undefined)).toBe('')
+  })
+
+  it('escapes complex csv values', () => {
+    const command = baseCommand({ format: 'csv', operation: 'find-many' })
+    const output = serializeOutput(command, [
+      {
+        name: 'Mr. Mime',
+        notes: 'line1\nline2',
+        quote: 'He said "hi"',
+        metadata: { region: 'kanto' },
+        capturedAt: new Date('2024-01-02T03:04:05.000Z')
+      }
+    ])
+
+    expect(output).toBe(
+      'name,notes,quote,metadata,capturedAt\nMr. Mime,"line1\nline2","He said ""hi""","{""region"":""kanto""}",2024-01-02T03:04:05.000Z'
+    )
+  })
+
+  it('renders nullish csv cell values as empty strings', () => {
+    const command = baseCommand({ format: 'csv', operation: 'find-many' })
+    const output = serializeOutput(command, [{ a: null, b: undefined, c: 'ok' }])
+
+    expect(output).toBe('a,b,c\n,,ok')
+  })
+
+  it('throws for unsupported output format', () => {
+    const command = baseCommand({
+      format: 'json'
+    }) as NormalizedReadCommand & { format: 'table' }
+
+    command.format = 'table'
+
+    expect(() => serializeOutput(command, { a: 1 })).toThrowError(
+      new CliError('Unsupported output format.')
+    )
   })
 })

--- a/src/cli/output/serializeOutput.ts
+++ b/src/cli/output/serializeOutput.ts
@@ -58,7 +58,7 @@ export function serializeOutput(
   }
 
   if (format === 'ndjson') {
-    if (operation === 'find-many') {
+    if (operation === 'find-many' || operation === 'find-many-or-throw') {
       const rows = Array.isArray(data) ? data : []
       return rows.map(row => JSON.stringify(row)).join('\n')
     }
@@ -66,10 +66,15 @@ export function serializeOutput(
   }
 
   if (format === 'csv') {
-    if (operation !== 'find-many') {
-      throw new CliError('Format "csv" is only supported for "read find-many".')
+    if (operation === 'describe') {
+      throw new CliError('Format "csv" is not supported for "read describe".')
     }
-    return toCsv(Array.isArray(data) ? (data as CliRecord[]) : [])
+    const rows = Array.isArray(data)
+      ? (data as CliRecord[])
+      : data
+        ? [data as CliRecord]
+        : []
+    return toCsv(rows)
   }
 
   throw new CliError('Unsupported output format.')

--- a/src/cli/output/writeOutput.spec.ts
+++ b/src/cli/output/writeOutput.spec.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { CliError } from '@/cli/errors/CliError'
+import { writeOutput } from '@/cli/output/writeOutput'
+
+describe('writeOutput', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('writes to stdout when output path is not provided', () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true)
+
+    writeOutput('hello')
+
+    expect(stdoutSpy).toHaveBeenCalledWith('hello\n')
+  })
+
+  it('writes to file when output path is provided', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-cli-output-'))
+    const outputPath = path.join(tempDir, 'nested', 'result.json')
+
+    writeOutput('{"ok":true}', outputPath)
+
+    const fileContent = fs.readFileSync(outputPath, 'utf8')
+    expect(fileContent).toBe('{"ok":true}')
+  })
+
+  it('throws CliError when writing file fails', () => {
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {
+      throw new Error('disk full')
+    })
+
+    expect(() => writeOutput('content', './out/file.txt')).toThrowError(
+      CliError
+    )
+  })
+})

--- a/src/cli/parse/parseReadFlags.spec.ts
+++ b/src/cli/parse/parseReadFlags.spec.ts
@@ -32,11 +32,14 @@ describe('parseReadFlags', () => {
       '--select',
       'name',
       '--select',
-      'rating'
+      'rating',
+      '--omit',
+      'instagram'
     ])
 
     expect(parsed.sheet).toBe('places')
     expect(parsed.select).toEqual(['name', 'rating'])
+    expect(parsed.omit).toEqual(['instagram'])
     expect(parsed.schemaBlocks).toEqual([
       { field: 'name', type: 'string' },
       { field: 'rating', type: 'number', nullable: true }
@@ -55,5 +58,128 @@ describe('parseReadFlags', () => {
 
   it('fails on unknown option', () => {
     expect(() => parseReadFlags(['--unknown', 'value'])).toThrowError(CliError)
+  })
+
+  it('parses inline values and boolean flags', () => {
+    const parsed = parseReadFlags([
+      '--config=./holysheets.cli.json',
+      '--spreadsheet-id=sheet-id',
+      '--sheet=pokemon',
+      '--header-row=2',
+      '--format=ndjson',
+      '--output=./out.ndjson',
+      '--pretty',
+      '--schema-file=./schema.json',
+      '--schema-json=[]',
+      '--where-field',
+      'id',
+      '--where-op',
+      'equals',
+      '--where-value',
+      '1'
+    ])
+
+    expect(parsed).toEqual({
+      config: './holysheets.cli.json',
+      spreadsheetId: 'sheet-id',
+      sheet: 'pokemon',
+      headerRow: '2',
+      format: 'ndjson',
+      output: './out.ndjson',
+      schemaFile: './schema.json',
+      schemaJson: '[]',
+      pretty: true,
+      select: [],
+      omit: [],
+      schemaBlocks: [],
+      whereBlocks: [{ field: 'id', op: 'equals', values: ['1'] }]
+    })
+  })
+
+  it('throws when receiving positional args', () => {
+    expect(() => parseReadFlags(['oops'])).toThrowError(
+      new CliError('Unexpected positional argument "oops".')
+    )
+  })
+
+  it('throws when value is missing', () => {
+    expect(() => parseReadFlags(['--sheet'])).toThrowError(
+      new CliError('Missing value for "--sheet".')
+    )
+  })
+
+  it('throws when boolean flag receives inline value', () => {
+    expect(() => parseReadFlags(['--pretty=true'])).toThrowError(
+      new CliError('Option "--pretty" does not accept a value.')
+    )
+  })
+
+  it('throws when schema-nullable is used before schema-field', () => {
+    expect(() => parseReadFlags(['--schema-nullable'])).toThrowError(
+      new CliError(
+        'Flag "--schema-nullable" must be used after "--schema-field".'
+      )
+    )
+  })
+
+  it('throws when schema-alias is used before schema-field', () => {
+    expect(() => parseReadFlags(['--schema-alias', 'x'])).toThrowError(
+      new CliError('Flag "--schema-alias" must be used after "--schema-field".')
+    )
+  })
+
+  it('throws on duplicate schema type for same field', () => {
+    expect(() =>
+      parseReadFlags([
+        '--schema-field',
+        'name',
+        '--schema-type',
+        'string',
+        '--schema-type',
+        'number'
+      ])
+    ).toThrowError(new CliError('Schema field "name" already has a type.'))
+  })
+
+  it('throws on duplicate schema alias for same field', () => {
+    expect(() =>
+      parseReadFlags([
+        '--schema-field',
+        'name',
+        '--schema-type',
+        'string',
+        '--schema-alias',
+        'n',
+        '--schema-alias',
+        'name2'
+      ])
+    ).toThrowError(new CliError('Schema field "name" already has an alias.'))
+  })
+
+  it('throws when where-op is used before where-field', () => {
+    expect(() => parseReadFlags(['--where-op', 'equals'])).toThrowError(
+      new CliError('Flag "--where-op" must be used after "--where-field".')
+    )
+  })
+
+  it('throws when where-value is used before where-field', () => {
+    expect(() => parseReadFlags(['--where-value', 'x'])).toThrowError(
+      new CliError('Flag "--where-value" must be used after "--where-field".')
+    )
+  })
+
+  it('throws on duplicate where-op in the same filter block', () => {
+    expect(() =>
+      parseReadFlags([
+        '--where-field',
+        'name',
+        '--where-op',
+        'contains',
+        '--where-op',
+        'equals'
+      ])
+    ).toThrowError(
+      new CliError('Filter for field "name" already has an operator.')
+    )
   })
 })

--- a/src/cli/parse/parseReadFlags.spec.ts
+++ b/src/cli/parse/parseReadFlags.spec.ts
@@ -84,6 +84,7 @@ describe('parseReadFlags', () => {
       spreadsheetId: 'sheet-id',
       sheet: 'pokemon',
       headerRow: '2',
+      skipSheetValidation: false,
       format: 'ndjson',
       output: './out.ndjson',
       schemaFile: './schema.json',
@@ -94,6 +95,11 @@ describe('parseReadFlags', () => {
       schemaBlocks: [],
       whereBlocks: [{ field: 'id', op: 'equals', values: ['1'] }]
     })
+  })
+
+  it('parses --skip-sheet-validation as a boolean flag', () => {
+    const parsed = parseReadFlags(['--skip-sheet-validation'])
+    expect(parsed.skipSheetValidation).toBe(true)
   })
 
   it('throws when receiving positional args', () => {
@@ -111,6 +117,14 @@ describe('parseReadFlags', () => {
   it('throws when boolean flag receives inline value', () => {
     expect(() => parseReadFlags(['--pretty=true'])).toThrowError(
       new CliError('Option "--pretty" does not accept a value.')
+    )
+  })
+
+  it('throws when --skip-sheet-validation receives inline value', () => {
+    expect(() =>
+      parseReadFlags(['--skip-sheet-validation=true'])
+    ).toThrowError(
+      new CliError('Option "--skip-sheet-validation" does not accept a value.')
     )
   })
 

--- a/src/cli/parse/parseReadFlags.ts
+++ b/src/cli/parse/parseReadFlags.ts
@@ -13,6 +13,7 @@ const VALUE_FLAGS = new Set([
   '--format',
   '--output',
   '--select',
+  '--omit',
   '--schema-file',
   '--schema-json',
   '--schema-field',
@@ -69,6 +70,7 @@ export function parseReadFlags(args: string[]): ParsedReadFlags {
   const parsed: ParsedReadFlags = {
     pretty: false,
     select: [],
+    omit: [],
     schemaBlocks: [],
     whereBlocks: []
   }
@@ -145,6 +147,9 @@ export function parseReadFlags(args: string[]): ParsedReadFlags {
       case '--select':
         parsed.select.push(value)
         break
+      case '--omit':
+        parsed.omit.push(value)
+        break
       case '--schema-file':
         parsed.schemaFile = value
         break
@@ -206,10 +211,6 @@ export function parseReadFlags(args: string[]): ParsedReadFlags {
         }
         currentWhereBlock.values.push(value)
         break
-      default:
-        throw new CliError(
-          `Unknown option "${name}". Use --help to list options.`
-        )
     }
   }
 

--- a/src/cli/parse/parseReadFlags.ts
+++ b/src/cli/parse/parseReadFlags.ts
@@ -24,7 +24,11 @@ const VALUE_FLAGS = new Set([
   '--where-value'
 ])
 
-const BOOLEAN_FLAGS = new Set(['--pretty', '--schema-nullable'])
+const BOOLEAN_FLAGS = new Set([
+  '--pretty',
+  '--schema-nullable',
+  '--skip-sheet-validation'
+])
 
 const ALL_FLAGS = new Set([...VALUE_FLAGS, ...BOOLEAN_FLAGS])
 
@@ -68,6 +72,7 @@ function readFlagValue(
 
 export function parseReadFlags(args: string[]): ParsedReadFlags {
   const parsed: ParsedReadFlags = {
+    skipSheetValidation: false,
     pretty: false,
     select: [],
     omit: [],
@@ -109,6 +114,10 @@ export function parseReadFlags(args: string[]): ParsedReadFlags {
 
       if (name === '--pretty') {
         parsed.pretty = true
+      }
+
+      if (name === '--skip-sheet-validation') {
+        parsed.skipSheetValidation = true
       }
 
       if (name === '--schema-nullable') {

--- a/src/cli/runCli.spec.ts
+++ b/src/cli/runCli.spec.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CliError } from '@/cli/errors/CliError'
+import { runCli } from '@/cli/runCli'
+import { parseReadFlags } from '@/cli/parse/parseReadFlags'
+import { readCliConfig } from '@/cli/config/readCliConfig'
+import { normalizeReadCommand } from '@/cli/normalize/normalizeReadCommand'
+import { runReadCommand } from '@/cli/commands/runReadCommand'
+import { serializeOutput } from '@/cli/output/serializeOutput'
+import { writeOutput } from '@/cli/output/writeOutput'
+
+vi.mock('@/cli/parse/parseReadFlags', () => ({
+  parseReadFlags: vi.fn()
+}))
+
+vi.mock('@/cli/config/readCliConfig', () => ({
+  readCliConfig: vi.fn()
+}))
+
+vi.mock('@/cli/normalize/normalizeReadCommand', () => ({
+  normalizeReadCommand: vi.fn()
+}))
+
+vi.mock('@/cli/commands/runReadCommand', () => ({
+  runReadCommand: vi.fn()
+}))
+
+vi.mock('@/cli/output/serializeOutput', () => ({
+  serializeOutput: vi.fn()
+}))
+
+vi.mock('@/cli/output/writeOutput', () => ({
+  writeOutput: vi.fn()
+}))
+
+function flushActions() {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('runCli', () => {
+  const defaultParsedFlags = {
+    pretty: false,
+    select: [],
+    omit: [],
+    schemaBlocks: [],
+    whereBlocks: []
+  }
+
+  const defaultNormalizedCommand = {
+    source: 'google-sheets' as const,
+    operation: 'find-many' as const,
+    spreadsheetId: 'id',
+    sheet: 'pokemon',
+    headerRow: 1,
+    format: 'json' as const,
+    output: './out.json',
+    pretty: false,
+    select: [],
+    omit: [],
+    where: {}
+  }
+
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    process.exitCode = undefined
+
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    vi.mocked(parseReadFlags).mockReturnValue(defaultParsedFlags)
+    vi.mocked(readCliConfig).mockReturnValue({})
+    vi.mocked(normalizeReadCommand).mockReturnValue(defaultNormalizedCommand)
+    vi.mocked(runReadCommand).mockResolvedValue([{ name: 'Bulbasaur' }])
+    vi.mocked(serializeOutput).mockReturnValue('SERIALIZED')
+    vi.mocked(writeOutput).mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('runs implicit source command and pipelines parse -> normalize -> run -> output', async () => {
+    runCli(['read', 'find-many', '--sheet', 'pokemon'])
+    await flushActions()
+
+    expect(parseReadFlags).toHaveBeenCalledWith(['--sheet', 'pokemon'])
+    expect(readCliConfig).toHaveBeenCalledWith(undefined)
+    expect(normalizeReadCommand).toHaveBeenCalledWith({
+      operation: 'find-many',
+      flags: defaultParsedFlags,
+      config: {}
+    })
+    expect(runReadCommand).toHaveBeenCalledWith(defaultNormalizedCommand)
+    expect(serializeOutput).toHaveBeenCalledWith(defaultNormalizedCommand, [
+      { name: 'Bulbasaur' }
+    ])
+    expect(writeOutput).toHaveBeenCalledWith('SERIALIZED', './out.json')
+  })
+
+  it('runs explicit source command with group=read', async () => {
+    runCli(['google-sheets', 'read', 'find-first', '--sheet', 'pokemon'])
+    await flushActions()
+
+    expect(parseReadFlags).toHaveBeenCalledWith(['--sheet', 'pokemon'])
+    expect(normalizeReadCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: 'find-first'
+      })
+    )
+  })
+
+  it('reports invalid command group for explicit source', async () => {
+    runCli(['google-sheets', 'write', 'find-many'])
+    await flushActions()
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'Invalid command group "write" for source "google-sheets". Use "read".\n'
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('reports invalid operation', async () => {
+    runCli(['read', 'invalid-op'])
+    await flushActions()
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid read command "invalid-op".')
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('handles CliError inside command execution', async () => {
+    vi.mocked(parseReadFlags).mockImplementationOnce(() => {
+      throw new CliError('bad flags', 2)
+    })
+
+    runCli(['read', 'find-many', '--sheet', 'pokemon'])
+    await flushActions()
+
+    expect(stderrSpy).toHaveBeenCalledWith('bad flags\n')
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('handles regular Error inside command execution', async () => {
+    vi.mocked(runReadCommand).mockRejectedValueOnce(
+      new Error('unexpected boom')
+    )
+
+    runCli(['read', 'find-many', '--sheet', 'pokemon'])
+    await flushActions()
+
+    expect(stderrSpy).toHaveBeenCalledWith('unexpected boom\n')
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('handles unknown thrown values inside command execution', async () => {
+    vi.mocked(runReadCommand).mockRejectedValueOnce('boom')
+
+    runCli(['read', 'find-many', '--sheet', 'pokemon'])
+    await flushActions()
+
+    expect(stderrSpy).toHaveBeenCalledWith('Unexpected CLI error.\n')
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/src/cli/runCli.spec.ts
+++ b/src/cli/runCli.spec.ts
@@ -39,6 +39,7 @@ function flushActions() {
 
 describe('runCli', () => {
   const defaultParsedFlags = {
+    skipSheetValidation: false,
     pretty: false,
     select: [],
     omit: [],
@@ -52,6 +53,7 @@ describe('runCli', () => {
     spreadsheetId: 'id',
     sheet: 'pokemon',
     headerRow: 1,
+    skipSheetValidation: false,
     format: 'json' as const,
     output: './out.json',
     pretty: false,

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -31,13 +31,20 @@ function readTailArgs(
   argv: string[],
   commandTokens: readonly string[]
 ): string[] {
-  if (argv.length < commandTokens.length) {
-    return []
-  }
   return argv.slice(commandTokens.length)
 }
 
-const READ_OPERATIONS: ReadOperation[] = ['find-many', 'find-first', 'describe']
+const READ_OPERATIONS: ReadOperation[] = [
+  'find-many',
+  'find-first',
+  'find-unique',
+  'find-last',
+  'find-many-or-throw',
+  'find-first-or-throw',
+  'find-unique-or-throw',
+  'find-last-or-throw',
+  'describe'
+]
 
 function isReadOperation(operation: string): operation is ReadOperation {
   return READ_OPERATIONS.includes(operation as ReadOperation)
@@ -74,6 +81,7 @@ function addReadOptions(command: Command): Command {
     )
     .option('--where-value <value>', 'Where value')
     .option('--select <field>', 'Select field (repeatable)')
+    .option('--omit <field>', 'Omit field (repeatable)')
 }
 
 async function executeReadFromCli(

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -65,6 +65,10 @@ function addReadOptions(command: Command): Command {
     .option('--spreadsheet-id <id>', 'Google Spreadsheet ID')
     .option('--sheet <name>', 'Sheet name')
     .option('--header-row <number>', 'Header row number (default: 1)')
+    .option(
+      '--skip-sheet-validation',
+      'Skip sheet-name validation before reading (faster, less safe)'
+    )
     .option('--format <json|csv|ndjson>', 'Output format (default: json)')
     .option('--output <path>', 'Write output to file instead of stdout')
     .option('--pretty', 'Pretty-print JSON output')

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -3,7 +3,16 @@ import { WhereClause } from '@/services/where/types/where.types'
 
 export type CliSource = 'google-sheets'
 
-export type ReadOperation = 'find-many' | 'find-first' | 'describe'
+export type ReadOperation =
+  | 'find-many'
+  | 'find-first'
+  | 'find-unique'
+  | 'find-last'
+  | 'find-many-or-throw'
+  | 'find-first-or-throw'
+  | 'find-unique-or-throw'
+  | 'find-last-or-throw'
+  | 'describe'
 
 export type OutputFormat = 'json' | 'csv' | 'ndjson'
 
@@ -33,6 +42,7 @@ export interface ParsedReadFlags {
   output?: string
   pretty: boolean
   select: string[]
+  omit: string[]
   schemaFile?: string
   schemaJson?: string
   schemaBlocks: ParsedSchemaFlagBlock[]
@@ -61,6 +71,7 @@ export interface NormalizedReadCommand {
   output?: string
   pretty: boolean
   select: string[]
+  omit: string[]
   where: WhereClause<CliRecord>
   schema?: RecordSchema<CliRecord>
 }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -38,6 +38,7 @@ export interface ParsedReadFlags {
   spreadsheetId?: string
   sheet?: string
   headerRow?: string
+  skipSheetValidation: boolean
   format?: string
   output?: string
   pretty: boolean
@@ -53,6 +54,7 @@ export interface CliConfigDefaults {
   spreadsheetId?: string
   sheet?: string
   headerRow?: number
+  skipSheetValidation?: boolean
   format?: OutputFormat
   pretty?: boolean
 }
@@ -67,6 +69,7 @@ export interface NormalizedReadCommand {
   spreadsheetId: string
   sheet: string
   headerRow: number
+  skipSheetValidation: boolean
   format: OutputFormat
   output?: string
   pretty: boolean

--- a/src/mixins/HolySheetsPublicBase/HolySheetsPublicBase.spec.ts
+++ b/src/mixins/HolySheetsPublicBase/HolySheetsPublicBase.spec.ts
@@ -1,5 +1,46 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { HolySheetsPublicBase } from '@/mixins/HolySheetsPublicBase/HolySheetsPublicBase'
+import { SheetNotFoundError } from '@/errors/SheetNotFoundError'
+
+function createJsonResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: () => Promise.resolve(JSON.stringify(payload))
+  } as Response
+}
+
+function createErrorResponse(status: number, statusText: string): Response {
+  return {
+    ok: false,
+    status,
+    statusText,
+    text: () => Promise.resolve('')
+  } as Response
+}
+
+function escapeJsString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+}
+
+const htmlViewWith = (
+  sheetNames: string[],
+  options: { spacedNameProp?: boolean } = {}
+) => {
+  const items = sheetNames
+    .map(
+      name =>
+        options.spacedNameProp
+          ? `items.push({ name : "${escapeJsString(name)}" , pageUrl: "https://example.com"})`
+          : `items.push({name: "${escapeJsString(name)}", pageUrl: "https://example.com"})`
+    )
+    .join(';')
+  return `<!doctype html><html><body><script>${items}</script></body></html>`
+}
 
 describe('HolySheetsPublicBase', () => {
   beforeEach(() => {
@@ -24,6 +65,12 @@ describe('HolySheetsPublicBase', () => {
     expect(base.headerRow).toBe(2)
   })
 
+  it('should set skipSheetValidation via options', () => {
+    const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
+    base.base('MySheet', { skipSheetValidation: true })
+    expect(base.skipSheetValidation).toBe(true)
+  })
+
   it('should default headerRow to 1', () => {
     const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
     expect(base.headerRow).toBe(1)
@@ -40,27 +87,32 @@ describe('HolySheetsPublicBase', () => {
   })
 
   it('should fetch headers via Visualization API', async () => {
-    const mockResponse = {
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          JSON.stringify({
-            version: '0.6',
-            reqId: '0',
-            status: 'ok',
-            table: {
-              cols: [
-                { id: 'A', label: 'name', type: 'string' },
-                { id: 'B', label: 'age', type: 'number' },
-                { id: 'C', label: 'city', type: 'string' }
-              ],
-              rows: []
-            }
-          })
-        )
-    }
-
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response)
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/htmlview')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            text: () => Promise.resolve(htmlViewWith(['Sheet1']))
+          } as Response
+        }
+        return createJsonResponse({
+          version: '0.6',
+          reqId: '0',
+          status: 'ok',
+          table: {
+            cols: [
+              { id: 'A', label: 'name', type: 'string' },
+              { id: 'B', label: 'age', type: 'number' },
+              { id: 'C', label: 'city', type: 'string' }
+            ],
+            rows: []
+          }
+        })
+      })
 
     const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
     base.base('Sheet1')
@@ -71,42 +123,101 @@ describe('HolySheetsPublicBase', () => {
       { header: 'age', column: 1 },
       { header: 'city', column: 2 }
     ])
-    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
 
   it('should cache headers for the same sheet', async () => {
-    const mockResponse = {
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          JSON.stringify({
-            version: '0.6',
-            reqId: '0',
-            status: 'ok',
-            table: {
-              cols: [{ id: 'A', label: 'name', type: 'string' }],
-              rows: []
-            }
-          })
-        )
-    }
-
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response)
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/htmlview')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            text: () => Promise.resolve(htmlViewWith(['Sheet1']))
+          } as Response
+        }
+        return createJsonResponse({
+          version: '0.6',
+          reqId: '0',
+          status: 'ok',
+          table: {
+            cols: [{ id: 'A', label: 'name', type: 'string' }],
+            rows: []
+          }
+        })
+      })
 
     const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
     base.base('Sheet1')
     await base.getHeaders()
     await base.getHeaders()
 
-    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
 
-  it('should throw when fetch fails', async () => {
+  it('should throw when worksheet validation fetch fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      createErrorResponse(404, 'Not Found')
+    )
+
+    const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
+    base.base('Sheet1')
+
+    await expect(base.getHeaders()).rejects.toThrow(
+      'Failed to validate sheet name'
+    )
+  })
+
+  it('should throw SheetNotFoundError when sheet is not in public tabs', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: 'Not Found'
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: () => Promise.resolve(htmlViewWith(['pokemon', 'moves']))
     } as Response)
+
+    const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
+    base.base('Sheet1')
+
+    await expect(base.getHeaders()).rejects.toThrow(
+      new SheetNotFoundError('Sheet1')
+    )
+  })
+
+  it('should throw when htmlview page has no parsable tabs', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: () => Promise.resolve('<html><body><p>No tabs</p></body></html>')
+    } as Response)
+
+    const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
+    base.base('Sheet1')
+
+    await expect(base.getHeaders()).rejects.toThrow(
+      'Failed to validate sheet name: no worksheet tabs found in public page.'
+    )
+  })
+
+  it('should throw when gviz fetch fails after successful worksheet validation', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/htmlview')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            text: () => Promise.resolve(htmlViewWith(['Sheet1']))
+          } as Response
+        }
+        return createErrorResponse(404, 'Not Found')
+      }
+    )
 
     const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
     base.base('Sheet1')
@@ -115,25 +226,32 @@ describe('HolySheetsPublicBase', () => {
   })
 
   it('should throw when visualization API returns error', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      text: () =>
-        Promise.resolve(
-          JSON.stringify({
-            version: '0.6',
-            reqId: '0',
-            status: 'error',
-            errors: [
-              {
-                reason: 'invalid_query',
-                message: 'Bad query',
-                detailed_message: 'Sheet not found'
-              }
-            ],
-            table: { cols: [], rows: [] }
-          })
-        )
-    } as Response)
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/htmlview')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            text: () => Promise.resolve(htmlViewWith(['Sheet1']))
+          } as Response
+        }
+        return createJsonResponse({
+          version: '0.6',
+          reqId: '0',
+          status: 'error',
+          errors: [
+            {
+              reason: 'invalid_query',
+              message: 'Bad query',
+              detailed_message: 'Sheet not found'
+            }
+          ],
+          table: { cols: [], rows: [] }
+        })
+      }
+    )
 
     const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
     base.base('Sheet1')
@@ -141,5 +259,129 @@ describe('HolySheetsPublicBase', () => {
     await expect(base.getHeaders()).rejects.toThrow(
       'Visualization API error: Sheet not found'
     )
+  })
+
+  it('should validate sheet name from htmlview metadata', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/htmlview')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            text: () => Promise.resolve(htmlViewWith(['pokemon', 'moves']))
+          } as Response
+        }
+
+        return createJsonResponse({
+          version: '0.6',
+          reqId: '0',
+          status: 'ok',
+          table: {
+            cols: [{ id: 'A', label: 'move_name', type: 'string' }],
+            rows: []
+          }
+        })
+      })
+
+    const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
+    base.base('moves')
+    const headers = await base.getHeaders()
+
+    expect(headers).toEqual([{ header: 'move_name', column: 0 }])
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should validate sheet name with escaped quotes in htmlview metadata', async () => {
+    const quotedName = 'R&D "Q1"'
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/htmlview')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            text: () => Promise.resolve(htmlViewWith([quotedName]))
+          } as Response
+        }
+
+        return createJsonResponse({
+          version: '0.6',
+          reqId: '0',
+          status: 'ok',
+          table: {
+            cols: [{ id: 'A', label: 'name', type: 'string' }],
+            rows: []
+          }
+        })
+      })
+
+    const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
+    base.base(quotedName)
+    const headers = await base.getHeaders()
+
+    expect(headers).toEqual([{ header: 'name', column: 0 }])
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should validate sheet name when name property has extra whitespace', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/htmlview')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            text: () =>
+              Promise.resolve(htmlViewWith(['Pokemon Moves'], { spacedNameProp: true }))
+          } as Response
+        }
+
+        return createJsonResponse({
+          version: '0.6',
+          reqId: '0',
+          status: 'ok',
+          table: {
+            cols: [{ id: 'A', label: 'name', type: 'string' }],
+            rows: []
+          }
+        })
+      })
+
+    const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
+    base.base('Pokemon Moves')
+    const headers = await base.getHeaders()
+
+    expect(headers).toEqual([{ header: 'name', column: 0 }])
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips sheet-name validation fetch when skipSheetValidation=true', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (_input: RequestInfo | URL) => {
+        return createJsonResponse({
+          version: '0.6',
+          reqId: '0',
+          status: 'ok',
+          table: {
+            cols: [{ id: 'A', label: 'name', type: 'string' }],
+            rows: []
+          }
+        })
+      })
+
+    const base = new HolySheetsPublicBase({ spreadsheetId: 'test-id' })
+    base.base('AnySheetName', { skipSheetValidation: true })
+    const headers = await base.getHeaders()
+
+    expect(headers).toEqual([{ header: 'name', column: 0 }])
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/mixins/HolySheetsPublicBase/HolySheetsPublicBase.ts
+++ b/src/mixins/HolySheetsPublicBase/HolySheetsPublicBase.ts
@@ -5,6 +5,7 @@ import {
   parseVisualizationResponse,
   buildGvizUrl
 } from '@/services/visualization/VisualizationQueryService'
+import { SheetNotFoundError } from '@/errors/SheetNotFoundError'
 
 export interface HolySheetsPublicCredentials {
   spreadsheetId: string
@@ -12,6 +13,7 @@ export interface HolySheetsPublicCredentials {
 
 interface HolySheetsPublicBaseOptions {
   headerRow?: number
+  skipSheetValidation?: boolean
 }
 
 export class HolySheetsPublicBase<
@@ -20,8 +22,10 @@ export class HolySheetsPublicBase<
   public sheet: string = ''
   public spreadsheetId: string
   public headerRow: number = 1
+  public skipSheetValidation: boolean = false
   public schema?: RecordSchema<RecordType>
   private readonly cachedHeaders: Map<string, HeaderColumn[]> = new Map()
+  private cachedSheetNames: Set<string> | null = null
 
   constructor(credentials: HolySheetsPublicCredentials) {
     this.spreadsheetId = credentials.spreadsheetId
@@ -32,6 +36,9 @@ export class HolySheetsPublicBase<
     if (options.headerRow !== undefined) {
       this.headerRow = options.headerRow
     }
+    if (options.skipSheetValidation !== undefined) {
+      this.skipSheetValidation = options.skipSheetValidation
+    }
     return this
   }
 
@@ -40,11 +47,162 @@ export class HolySheetsPublicBase<
     return this
   }
 
+  private buildHtmlViewUrl(): string {
+    return `https://docs.google.com/spreadsheets/d/${encodeURIComponent(this.spreadsheetId)}/htmlview`
+  }
+
+  private decodeEscapedString(value: string): string {
+    return value
+      .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex: string) =>
+        String.fromCharCode(Number.parseInt(hex, 16))
+      )
+      .replace(/\\n/g, '\n')
+      .replace(/\\r/g, '\r')
+      .replace(/\\t/g, '\t')
+      .replace(/\\b/g, '\b')
+      .replace(/\\f/g, '\f')
+      .replace(/\\"/g, '"')
+      .replace(/\\'/g, "'")
+      .replace(/\\\\/g, '\\')
+      .trim()
+  }
+
+  private decodeHtmlEntities(value: string): string {
+    return value
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .trim()
+  }
+
+  private readQuotedString(
+    source: string,
+    quoteStart: number
+  ): { value: string; endIndex: number } | null {
+    const quote = source[quoteStart]
+    if (quote !== '"' && quote !== "'") {
+      return null
+    }
+
+    let cursor = quoteStart + 1
+    let raw = ''
+
+    while (cursor < source.length) {
+      const current = source[cursor]
+      if (current === '\\') {
+        if (cursor + 1 < source.length) {
+          raw += source.slice(cursor, cursor + 2)
+          cursor += 2
+          continue
+        }
+        raw += current
+        cursor += 1
+        continue
+      }
+      if (current === quote) {
+        return { value: raw, endIndex: cursor + 1 }
+      }
+      raw += current
+      cursor += 1
+    }
+
+    return null
+  }
+
+  private addSheetName(target: Set<string>, raw: string): void {
+    const decoded = this.decodeHtmlEntities(this.decodeEscapedString(raw))
+    if (decoded.length > 0) {
+      target.add(decoded)
+    }
+  }
+
+  private extractSheetNamesFromItemsPushBlocks(html: string): Set<string> {
+    const names = new Set<string>()
+    const itemRegex = /items\.push\(\{[\s\S]*?\}\)/gi
+    let itemMatch: RegExpExecArray | null = null
+    while ((itemMatch = itemRegex.exec(html)) !== null) {
+      const block = itemMatch[0]
+      const namePropRegex = /\bname\b\s*:\s*/gi
+      const propMatch = namePropRegex.exec(block)
+      if (!propMatch) {
+        continue
+      }
+      let cursor = namePropRegex.lastIndex
+      while (cursor < block.length && /\s/.test(block[cursor])) {
+        cursor += 1
+      }
+      const parsed = this.readQuotedString(block, cursor)
+      if (!parsed) {
+        continue
+      }
+      this.addSheetName(names, parsed.value)
+    }
+    return names
+  }
+
+  private extractSheetNamesFromAnchorTabs(html: string): Set<string> {
+    const names = new Set<string>()
+    const tabAnchorRegex =
+      /<a\b[^>]*href="[^"]*gid=-?\d+[^"]*"[^>]*>([\s\S]*?)<\/a>/gi
+    let tabMatch: RegExpExecArray | null = null
+    while ((tabMatch = tabAnchorRegex.exec(html)) !== null) {
+      const text = tabMatch[1].replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim()
+      this.addSheetName(names, text)
+    }
+    return names
+  }
+
+  private extractSheetNamesFromHtmlView(html: string): Set<string> {
+    const names = this.extractSheetNamesFromItemsPushBlocks(html)
+    for (const name of this.extractSheetNamesFromAnchorTabs(html)) {
+      names.add(name)
+    }
+    return names
+  }
+
+  private async getPublicSheetNames(): Promise<Set<string>> {
+    if (this.cachedSheetNames) {
+      return this.cachedSheetNames
+    }
+
+    const response = await fetch(this.buildHtmlViewUrl())
+    if (!response.ok) {
+      throw new Error(
+        `Failed to validate sheet name: ${response.status} ${response.statusText}`
+      )
+    }
+
+    const html = await response.text()
+    const names = this.extractSheetNamesFromHtmlView(html)
+
+    if (names.size === 0) {
+      throw new Error(
+        'Failed to validate sheet name: no worksheet tabs found in public page.'
+      )
+    }
+
+    this.cachedSheetNames = names
+    return names
+  }
+
+  private async validateSheetExists(): Promise<void> {
+    const sheetNames = await this.getPublicSheetNames()
+    if (!sheetNames.has(this.sheet)) {
+      throw new SheetNotFoundError(this.sheet)
+    }
+  }
+
   public async getHeaders(): Promise<HeaderColumn[]> {
     const cacheKey = `${this.spreadsheetId}:${this.sheet}:${this.headerRow}`
     const cached = this.cachedHeaders.get(cacheKey)
     if (cached) {
       return cached
+    }
+
+    if (!this.skipSheetValidation) {
+      await this.validateSheetExists()
     }
 
     const fullUrl = buildGvizUrl(

--- a/src/mixins/WithClearOperations/WithClearOperations.spec.ts
+++ b/src/mixins/WithClearOperations/WithClearOperations.spec.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import HolySheets from '@/index'
+import { ClearOperation } from '@/operations/clear/ClearOperation'
+import { MultipleRecordsFoundForUniqueError } from '@/errors/MultipleRecordsFoundForUniqueError'
+import { RecordNotFoundError } from '@/errors/RecordNotFoundError'
 import type {
   OperationOptions,
-  OperationConfigs
+  OperationConfigs,
+  OperationOptionsWithSlice
 } from '@/operations/types/BaseOperation.types'
 
 interface DummyRecord {
@@ -16,10 +20,8 @@ const dummyCredentials = {
   auth: dummyAuth
 }
 
-// Dummy headers returned by HeaderService
 const dummyHeaders = [{ header: 'A', column: 0 }]
 
-// Mock ClearOperation
 vi.mock('@/operations/clear/ClearOperation', () => {
   const mockExecute = vi.fn().mockResolvedValue([{ id: 1 }, { id: 2 }])
   return {
@@ -29,10 +31,8 @@ vi.mock('@/operations/clear/ClearOperation', () => {
   }
 })
 
-// Test setup utility
 const setupTestEnvironment = () => {
   const instance = new HolySheets<DummyRecord>(dummyCredentials)
-  // Override getHeaders to return dummyHeaders
   instance['headerService'].getHeaders = vi.fn().mockResolvedValue(dummyHeaders)
   return instance.base('TestSheet', { headerRow: 2 })
 }
@@ -40,14 +40,156 @@ const setupTestEnvironment = () => {
 describe('Clear Operations', () => {
   let instance: HolySheets<DummyRecord>
   const dummyOptions: OperationOptions<DummyRecord> = {}
-  const dummyConfigs: OperationConfigs = {}
+  const sliceOptions: OperationOptionsWithSlice<DummyRecord> = {
+    slice: [3, 5]
+  }
+  const dummyConfigs: OperationConfigs = { returnRecords: true }
 
   beforeEach(() => {
     instance = setupTestEnvironment()
+    vi.clearAllMocks()
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      executeOperation: vi.fn().mockResolvedValue([{ id: 1 }, { id: 2 }])
+    }))
   })
 
   it('clearMany should return records after clear operation', async () => {
     const result = await instance.clearMany(dummyOptions, dummyConfigs)
     expect(result).toEqual([{ id: 1 }, { id: 2 }])
+    expect(ClearOperation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slice: [0] }),
+      dummyConfigs
+    )
+  })
+
+  it('clearSlice should use provided slice', async () => {
+    const result = await instance.clearSlice(sliceOptions, dummyConfigs)
+    expect(result).toEqual([{ id: 1 }, { id: 2 }])
+    expect(ClearOperation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slice: [3, 5] }),
+      dummyConfigs
+    )
+  })
+
+  it('clearFirst should return first item and use [0, 1] slice', async () => {
+    const result = await instance.clearFirst(dummyOptions, dummyConfigs)
+    expect(result).toEqual({ id: 1 })
+    expect(ClearOperation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slice: [0, 1] }),
+      dummyConfigs
+    )
+  })
+
+  it('clearUnique should throw if more than one record is returned', async () => {
+    await expect(
+      instance.clearUnique(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(MultipleRecordsFoundForUniqueError)
+  })
+
+  it('clearUnique should return a single record when only one is returned', async () => {
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([{ id: 1 }])
+    }))
+
+    const result = await instance.clearUnique(dummyOptions, dummyConfigs)
+    expect(result).toEqual({ id: 1 })
+    expect(ClearOperation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slice: [0, 2] }),
+      dummyConfigs
+    )
+  })
+
+  it('clearLast should return first item from [-1] slice result', async () => {
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([{ id: 99 }])
+    }))
+
+    const result = await instance.clearLast(dummyOptions, dummyConfigs)
+    expect(result).toEqual({ id: 99 })
+    expect(ClearOperation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slice: [-1] }),
+      dummyConfigs
+    )
+  })
+
+  it('clearAll should behave like clearMany', async () => {
+    const result = await instance.clearAll(dummyOptions, dummyConfigs)
+    expect(result).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('clearSliceOrThrow should throw RecordNotFoundError when operation returns no records', async () => {
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.clearSliceOrThrow(sliceOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('clearManyOrThrow should throw RecordNotFoundError when operation returns no records', async () => {
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.clearManyOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('clearFirstOrThrow should return first record when found', async () => {
+    const result = await instance.clearFirstOrThrow(dummyOptions, dummyConfigs)
+    expect(result).toEqual({ id: 1 })
+  })
+
+  it('clearFirstOrThrow should throw RecordNotFoundError when no record exists', async () => {
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.clearFirstOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('clearUniqueOrThrow should throw MultipleRecordsFoundForUniqueError for multiple results', async () => {
+    await expect(
+      instance.clearUniqueOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(MultipleRecordsFoundForUniqueError)
+  })
+
+  it('clearUniqueOrThrow should throw RecordNotFoundError for no results', async () => {
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.clearUniqueOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('clearLastOrThrow should throw RecordNotFoundError when operation returns no records', async () => {
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.clearLastOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('clearAllOrThrow should throw RecordNotFoundError when operation returns no records', async () => {
+    ;(ClearOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.clearAllOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
   })
 })

--- a/src/mixins/WithDeleteOperations/WithDeleteOperations.spec.ts
+++ b/src/mixins/WithDeleteOperations/WithDeleteOperations.spec.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import HolySheets from '@/index'
 import { DeleteOperation } from '@/operations/delete/DeleteOperation'
 import { MultipleRecordsFoundForUniqueError } from '@/errors/MultipleRecordsFoundForUniqueError'
+import { RecordNotFoundError } from '@/errors/RecordNotFoundError'
 import type {
   OperationOptions,
-  OperationConfigs
+  OperationConfigs,
+  OperationOptionsWithSlice
 } from '@/operations/types/BaseOperation.types'
 
 interface DummyRecord {
@@ -36,6 +38,9 @@ const setupTestEnvironment = () => {
 describe('WithDeleteOperations', () => {
   let instance: HolySheets<DummyRecord>
   const dummyOptions: OperationOptions<DummyRecord> = {}
+  const sliceOptions: OperationOptionsWithSlice<DummyRecord> = {
+    slice: [2, 4]
+  }
   const dummyConfigs: OperationConfigs = { returnRecords: true }
 
   beforeEach(() => {
@@ -78,5 +83,91 @@ describe('WithDeleteOperations', () => {
   it('deleteAll should return all records', async () => {
     const result = await instance.deleteAll(dummyOptions, dummyConfigs)
     expect(result).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('deleteSlice should use provided slice', async () => {
+    const result = await instance.deleteSlice(sliceOptions, dummyConfigs)
+    expect(result).toEqual([{ id: 1 }, { id: 2 }])
+    expect(DeleteOperation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slice: [2, 4] }),
+      dummyConfigs
+    )
+  })
+
+  it('deleteSliceOrThrow should use provided slice and throw when empty', async () => {
+    ;(DeleteOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.deleteSliceOrThrow(sliceOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+    expect(DeleteOperation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slice: [2, 4] }),
+      dummyConfigs
+    )
+  })
+
+  it('deleteManyOrThrow should throw RecordNotFoundError when no records are returned', async () => {
+    ;(DeleteOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.deleteManyOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('deleteFirstOrThrow should return first record when found', async () => {
+    const result = await instance.deleteFirstOrThrow(dummyOptions, dummyConfigs)
+    expect(result).toEqual({ id: 1 })
+  })
+
+  it('deleteFirstOrThrow should throw RecordNotFoundError when empty', async () => {
+    ;(DeleteOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.deleteFirstOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('deleteUniqueOrThrow should throw for multiple results', async () => {
+    await expect(
+      instance.deleteUniqueOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(MultipleRecordsFoundForUniqueError)
+  })
+
+  it('deleteUniqueOrThrow should throw RecordNotFoundError when empty', async () => {
+    ;(DeleteOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.deleteUniqueOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('deleteLastOrThrow should throw RecordNotFoundError when empty', async () => {
+    ;(DeleteOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.deleteLastOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('deleteAllOrThrow should throw RecordNotFoundError when empty', async () => {
+    ;(DeleteOperation as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      executeOperation: vi.fn().mockResolvedValue([])
+    }))
+
+    await expect(
+      instance.deleteAllOrThrow(dummyOptions, dummyConfigs)
+    ).rejects.toThrow(RecordNotFoundError)
   })
 })

--- a/src/services/google-sheets/adapter/GoogleSheetsAdapter.spec.ts
+++ b/src/services/google-sheets/adapter/GoogleSheetsAdapter.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GoogleSheetsAdapter } from './GoogleSheetsAdapter'
-import { HolySheetsCredentials } from '@/types/credentials'
+import { HolySheetsCredentials } from '@/services/google-sheets/types/credentials.type'
 import { IGoogleSheetsService } from '@/services/google-sheets/IGoogleSheetsService'
 import { SheetNotFoundError } from '@/errors/SheetNotFoundError'
 
@@ -18,106 +18,226 @@ describe('GoogleSheetsAdapter', () => {
     mockSheetService = {
       getValues: vi.fn(),
       batchGetValues: vi.fn(),
+      appendValues: vi.fn(),
+      batchClearValues: vi.fn(),
+      batchUpdateValues: vi.fn(),
       getAuth: vi.fn()
     } as unknown as IGoogleSheetsService
 
     adapter = new GoogleSheetsAdapter(credentials, undefined)
-    adapter['sheetService'] = mockSheetService
+    ;(adapter as any).sheetService = mockSheetService
+    ;(adapter as any).sheets = {
+      spreadsheets: {
+        get: vi.fn(),
+        batchUpdate: vi.fn()
+      }
+    }
   })
 
   it('should get a single row', async () => {
-    const sheetName = 'Sheet1'
-    const rowIndex = 1
     const expectedRow = ['A1', 'B1', 'C1']
-    mockSheetService.getValues = vi.fn().mockResolvedValue([expectedRow])
+    ;(mockSheetService.getValues as ReturnType<typeof vi.fn>).mockResolvedValue([
+      expectedRow
+    ])
 
-    const result = await adapter.getSingleRow(sheetName, rowIndex)
+    const result = await adapter.getSingleRow('Sheet1', 1)
 
     expect(result).toEqual(expectedRow)
-    expect(mockSheetService.getValues).toHaveBeenCalledWith(`${sheetName}!1:1`)
+    expect(mockSheetService.getValues).toHaveBeenCalledWith('Sheet1!1:1')
   })
 
-  it.skip('should get multiple rows', async () => {
-    const sheetName = 'Sheet1'
-    const rowIndexes = [1, 2]
-    const expectedRows = [
-      ['A1', 'B1', 'C1'],
-      ['A2', 'B2', 'C2']
-    ]
-    mockSheetService.batchGetValues = vi.fn().mockResolvedValue(expectedRows)
+  it('should get multiple rows', async () => {
+    ;(mockSheetService.batchGetValues as ReturnType<typeof vi.fn>).mockResolvedValue(
+      [[['A1', 'B1']], [['A2', 'B2']]]
+    )
 
-    const result = await adapter.getMultipleRows(sheetName, rowIndexes)
-    expect(result).toEqual(expectedRows)
+    const result = await adapter.getMultipleRows('Sheet1', [1, 2])
+
+    expect(result).toEqual([
+      ['A1', 'B1'],
+      ['A2', 'B2']
+    ])
     expect(mockSheetService.batchGetValues).toHaveBeenCalledWith([
-      `${sheetName}!1:1`,
-      `${sheetName}!2:2`
+      'Sheet1!1:1',
+      'Sheet1!2:2'
     ])
   })
 
-  it.skip('should get multiple columns', async () => {
-    const sheetName = 'Sheet1'
-    const columnIndexes = [1, 2]
-    const expectedColumns = [
+  it('should append multiple rows', async () => {
+    const rows = [
+      ['1', 'Bulbasaur'],
+      ['2', 'Ivysaur']
+    ]
+
+    await adapter.appendMultipleRows('Sheet1', rows)
+
+    expect(mockSheetService.appendValues).toHaveBeenCalledWith('Sheet1', rows)
+  })
+
+  it('should get multiple columns', async () => {
+    ;(mockSheetService.batchGetValues as ReturnType<typeof vi.fn>).mockResolvedValue(
+      [[['A1'], ['A2']], [['B1'], ['B2']]]
+    )
+
+    const result = await adapter.getMultipleColumns('Sheet1', [1, 2])
+
+    expect(result).toEqual([
       ['A1', 'A2'],
       ['B1', 'B2']
-    ]
-    mockSheetService.batchGetValues = vi.fn().mockResolvedValue(expectedColumns)
-
-    const result = await adapter.getMultipleColumns(sheetName, columnIndexes)
-
-    expect(result).toEqual(expectedColumns)
-    expect(mockSheetService.batchGetValues).toHaveBeenCalledWith([
-      `${sheetName}!A:A`,
-      `${sheetName}!B:B`
     ])
+    expect(mockSheetService.batchGetValues).toHaveBeenCalledWith([
+      'Sheet1!B2:B',
+      'Sheet1!C2:C'
+    ])
+  })
+
+  it('should clear multiple rows', async () => {
+    await adapter.clearMultipleRows('Sheet1', [2, 4])
+
+    expect(mockSheetService.batchClearValues).toHaveBeenCalledWith([
+      'Sheet1!2:2',
+      'Sheet1!4:4'
+    ])
+  })
+
+  it('should update multiple rows', async () => {
+    const rowIndexes = [3, 5]
+    const data = [
+      ['x', 'y'],
+      ['z', null]
+    ]
+
+    await adapter.updateMultipleRows('Sheet1', rowIndexes, data)
+
+    expect(mockSheetService.batchUpdateValues).toHaveBeenCalledWith([
+      { range: 'Sheet1!3:3', values: [['x', 'y']] },
+      { range: 'Sheet1!5:5', values: [['z', null]] }
+    ])
+  })
+
+  it('should delete rows sorted from bottom to top', async () => {
+    vi.spyOn(adapter, 'getSheetId').mockResolvedValue(42)
+    const batchUpdate = vi.fn().mockResolvedValue({})
+    ;(adapter as any).sheets = {
+      spreadsheets: {
+        batchUpdate
+      }
+    }
+
+    await adapter.deleteRows('Sheet1', [2, 5, 3])
+
+    expect(batchUpdate).toHaveBeenCalledWith({
+      spreadsheetId: credentials.spreadsheetId,
+      requestBody: {
+        requests: [
+          {
+            deleteDimension: {
+              range: {
+                sheetId: 42,
+                dimension: 'ROWS',
+                startIndex: 4,
+                endIndex: 5
+              }
+            }
+          },
+          {
+            deleteDimension: {
+              range: {
+                sheetId: 42,
+                dimension: 'ROWS',
+                startIndex: 2,
+                endIndex: 3
+              }
+            }
+          },
+          {
+            deleteDimension: {
+              range: {
+                sheetId: 42,
+                dimension: 'ROWS',
+                startIndex: 1,
+                endIndex: 2
+              }
+            }
+          }
+        ]
+      }
+    })
   })
 
   it('should get spreadsheet', async () => {
     const expectedSpreadsheet = { spreadsheetId: 'test-spreadsheet-id' }
-    adapter['sheets'] = {
+    ;(adapter as any).sheets = {
       spreadsheets: {
         get: vi.fn().mockResolvedValue({ data: expectedSpreadsheet })
       }
-    } as any
+    }
 
     const result = await adapter.getSpreadsheet()
 
     expect(result).toEqual(expectedSpreadsheet)
-    expect(adapter['sheets'].spreadsheets.get).toHaveBeenCalledWith({
+    expect((adapter as any).sheets.spreadsheets.get).toHaveBeenCalledWith({
       spreadsheetId: credentials.spreadsheetId
     })
   })
 
   it('should get sheet id', async () => {
-    const sheetName = 'Sheet1'
-    const expectedSheetId = 123
-    const spreadsheet = {
-      sheets: [{ properties: { title: sheetName, sheetId: expectedSheetId } }]
-    }
-    vi.spyOn(adapter, 'getSpreadsheet').mockResolvedValue(spreadsheet as any)
+    vi.spyOn(adapter, 'getSpreadsheet').mockResolvedValue({
+      sheets: [{ properties: { title: 'Sheet1', sheetId: 123 } }]
+    } as any)
 
-    const result = await adapter.getSheetId(sheetName)
+    const result = await adapter.getSheetId('Sheet1')
 
-    expect(result).toEqual(expectedSheetId)
+    expect(result).toBe(123)
   })
 
-  it('should throw SheetNotFoundError if sheet not found', async () => {
-    const sheetName = 'NonExistentSheet'
-    const spreadsheet = { sheets: [] }
-    vi.spyOn(adapter, 'getSpreadsheet').mockResolvedValue(spreadsheet as any)
+  it('should return sheet id 0 when sheet exists without sheetId', async () => {
+    vi.spyOn(adapter, 'getSpreadsheet').mockResolvedValue({
+      sheets: [{ properties: { title: 'Sheet1' } }]
+    } as any)
 
-    await expect(adapter.getSheetId(sheetName)).rejects.toThrow(
-      new SheetNotFoundError(sheetName)
+    const result = await adapter.getSheetId('Sheet1')
+
+    expect(result).toBe(0)
+  })
+
+  it('should throw SheetNotFoundError if sheet is not found', async () => {
+    vi.spyOn(adapter, 'getSpreadsheet').mockResolvedValue({ sheets: [] } as any)
+
+    await expect(adapter.getSheetId('MissingSheet')).rejects.toThrow(
+      new SheetNotFoundError('MissingSheet')
     )
   })
 
   it('should get auth client', () => {
     const authClient = { client: 'auth-client' }
-    mockSheetService.getAuth = vi.fn().mockReturnValue(authClient)
+    ;(mockSheetService.getAuth as ReturnType<typeof vi.fn>).mockReturnValue(
+      authClient
+    )
 
     const result = adapter.getAuth()
 
     expect(result).toEqual(authClient)
     expect(mockSheetService.getAuth).toHaveBeenCalled()
+  })
+
+  it('should use injected sheets instance when provided in constructor', async () => {
+    const spreadsheetsGet = vi.fn().mockResolvedValue({ data: { sheets: [] } })
+    const injectedSheets = {
+      spreadsheets: {
+        get: spreadsheetsGet
+      }
+    } as any
+
+    const adapterWithInjectedSheets = new GoogleSheetsAdapter(
+      credentials,
+      injectedSheets
+    )
+
+    await adapterWithInjectedSheets.getSpreadsheet()
+
+    expect(spreadsheetsGet).toHaveBeenCalledWith({
+      spreadsheetId: credentials.spreadsheetId
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add `skipSheetValidation` support to public base options
- add CLI flag `--skip-sheet-validation` and config default support
- wire normalized option into `HolySheets.public().base(...)`
- keep strict validation as default while providing an explicit opt-out
- improve public htmlview sheet-name parsing robustness

## Tests
- pnpm vitest run
- pnpm build

## Docs
- update README CLI section
- update CLI docs (`commands`, `configuration`, `overview`)
- update public mode guide with the new option
